### PR TITLE
Réglage du problème de Checkbox collées

### DIFF
--- a/front/src/Apps/Companies/AccountCompanyAdd/AccountCompanyAdd.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/AccountCompanyAdd.tsx
@@ -33,12 +33,11 @@ import {
   isValidWebsite
 } from "@td/constants";
 import { CREATE_WORKER_CERTIFICATION } from "../../Account/fields/forms/AccountFormCompanyWorkerCertification";
-import { Checkbox } from "@codegouvfr/react-dsfr/Checkbox";
 import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
-
+import SingleCheckbox from "../../common/Components/SingleCheckbox/SingleCheckbox";
 import GivenNameNotice from "../common/Components/GivenNameNotice/GivenNameNotice";
 import FormikCompanyTypeForm, {
   FormikCompanyTypeValues
@@ -769,7 +768,7 @@ export default function AccountCompanyAdd() {
                       <Field name="isAllowed">
                         {({ field }) => {
                           return (
-                            <Checkbox
+                            <SingleCheckbox
                               state={
                                 errors.isAllowed && touched.isAllowed
                                   ? "error"

--- a/front/src/Apps/Companies/AccountCompanyAdd/AccountCompanyAddForeign.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/AccountCompanyAddForeign.tsx
@@ -17,8 +17,8 @@ import { isSiret, isVat } from "@td/constants";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
-import { Checkbox } from "@codegouvfr/react-dsfr/Checkbox";
 import { CREATE_COMPANY } from "../common/queries";
+import SingleCheckbox from "../../common/Components/SingleCheckbox/SingleCheckbox";
 
 interface Values extends FormikValues {
   vatNumber: string;
@@ -318,7 +318,7 @@ export default function AccountCompanyAddForeign() {
                   <Field name="isAllowed">
                     {({ field }) => {
                       return (
-                        <Checkbox
+                        <SingleCheckbox
                           state={
                             errors.isAllowed && touched.isAllowed
                               ? "error"

--- a/front/src/Apps/Companies/AccountCompanyAdd/AccountCompanyAddProducer.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/AccountCompanyAddProducer.tsx
@@ -16,12 +16,12 @@ import { isSiret, isVat } from "@td/constants";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Input } from "@codegouvfr/react-dsfr/Input";
-import { Checkbox } from "@codegouvfr/react-dsfr/Checkbox";
 import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
 
 import { CREATE_COMPANY_HOOK_OPTIONS } from "./AccountCompanyAdd";
 import { CREATE_COMPANY } from "../common/queries";
 import GivenNameNotice from "../common/Components/GivenNameNotice/GivenNameNotice";
+import SingleCheckbox from "../../common/Components/SingleCheckbox/SingleCheckbox";
 
 interface Values extends FormikValues {
   siret?: string | null;
@@ -261,7 +261,7 @@ export default function AccountCompanyAddProducer() {
                   <Field name="isAllowed">
                     {({ field }) => {
                       return (
-                        <Checkbox
+                        <SingleCheckbox
                           state={
                             errors.isAllowed && touched.isAllowed
                               ? "error"

--- a/front/src/Apps/Companies/CompanyInfo/CompanyProfileInformation.tsx
+++ b/front/src/Apps/Companies/CompanyInfo/CompanyProfileInformation.tsx
@@ -7,7 +7,7 @@ import {
   WASTE_PROCESSOR_TYPE_OPTIONS,
   formatDateViewDisplay
 } from "../common/utils";
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
+import SingleCheckbox from "../../common/Components/SingleCheckbox/SingleCheckbox";
 
 interface CompanyProfileFormProps {
   company: CompanyPrivate;
@@ -47,7 +47,7 @@ const CompanyProfileInformation = ({ company }: CompanyProfileFormProps) => {
         return (
           companyType.isChecked && (
             <li key={companyType.value}>
-              <Checkbox
+              <SingleCheckbox
                 options={[
                   {
                     label: companyType.label,
@@ -275,7 +275,7 @@ const CompanyProfileInformation = ({ company }: CompanyProfileFormProps) => {
                       );
                     if (wasteProcessorFound) {
                       return (
-                        <Checkbox
+                        <SingleCheckbox
                           key={wasteProcessorFound.value}
                           options={[
                             {
@@ -301,7 +301,7 @@ const CompanyProfileInformation = ({ company }: CompanyProfileFormProps) => {
                     );
                     if (collectorFound) {
                       return (
-                        <Checkbox
+                        <SingleCheckbox
                           key={collectorFound.value}
                           options={[
                             {

--- a/front/src/Apps/Companies/CompanyManage/CompanyAdminRequest/CompanyCreateAdminRequestModal/CompanyCreateAdminRequestModalStep3.tsx
+++ b/front/src/Apps/Companies/CompanyManage/CompanyAdminRequest/CompanyCreateAdminRequestModal/CompanyCreateAdminRequestModalStep3.tsx
@@ -1,8 +1,8 @@
 import Alert from "@codegouvfr/react-dsfr/Alert";
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import React, { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { AdminRequestValidationMethod } from "@td/codegen-ui";
+import SingleCheckbox from "../../../../common/Components/SingleCheckbox/SingleCheckbox";
 
 const ADMINS_WARNED_ALERT =
   "Les administrateurs même inactifs sont prévenus de la demande.";
@@ -74,7 +74,7 @@ export const CompanyCreateAdminRequestModalStep3 = ({
       </div>
 
       <div>
-        <Checkbox
+        <SingleCheckbox
           style={{ fontWeight: "bold" }}
           options={[
             {

--- a/front/src/Apps/Companies/common/Components/CompanyTypeForm/CompanyTypeCheckbox.tsx
+++ b/front/src/Apps/Companies/common/Components/CompanyTypeForm/CompanyTypeCheckbox.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode } from "react";
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import Tooltip from "../../../../common/Components/Tooltip/Tooltip";
 import { AllCompanyType, CompanySubTypeOption } from "../../utils";
 import Highlight from "@codegouvfr/react-dsfr/Highlight";
@@ -9,6 +8,7 @@ import {
   CompanyTypeInputProps,
   CompanyTypeInputValues
 } from "./CompanyTypeForm";
+import SingleCheckbox from "../../../../common/Components/SingleCheckbox/SingleCheckbox";
 
 type CompanyTypeCheckboxProps = {
   label: string;
@@ -60,7 +60,7 @@ const CompanyTypeCheckbox = ({
     <div key={value}>
       <div>
         <div>
-          <Checkbox
+          <SingleCheckbox
             options={[
               {
                 label: labelWithHelp,

--- a/front/src/Apps/Companies/common/Components/CompanyTypeForm/WorkerCertificationForm.tsx
+++ b/front/src/Apps/Companies/common/Components/CompanyTypeForm/WorkerCertificationForm.tsx
@@ -1,4 +1,3 @@
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import Input from "@codegouvfr/react-dsfr/Input";
 import Select from "@codegouvfr/react-dsfr/SelectNext";
 import React from "react";
@@ -9,6 +8,7 @@ import {
 } from "./CompanyTypeForm";
 import Tooltip from "../../../../common/Components/Tooltip/Tooltip";
 import { WORKER_AGREMENT_ORGANISATION_OPTIONS } from "../../utils";
+import SingleCheckbox from "../../../../common/Components/SingleCheckbox/SingleCheckbox";
 
 type WorkerCategoryFormProps = {
   inputValues: Pick<CompanyTypeInputValues, "workerCertification">;
@@ -25,7 +25,7 @@ const WorkerCertificationForm = ({
     <div style={{ paddingTop: "4px" }}>
       <div>
         <div>
-          <Checkbox
+          <SingleCheckbox
             options={[
               {
                 label: "Travaux relevant de la sous-section 4",
@@ -39,7 +39,7 @@ const WorkerCertificationForm = ({
       </div>
       <div>
         <div>
-          <Checkbox
+          <SingleCheckbox
             options={[
               {
                 label: (

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
@@ -10,8 +10,8 @@ import CompanyContactInfo from "../../../../Forms/Components/RhfCompanyContactIn
 import DisabledParagraphStep from "../../DisabledParagraphStep";
 import { SealedFieldsContext } from "../../../../Dashboard/Creation/context";
 import { clearCompanyError, setFieldError } from "../../utils";
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import DsfrfWorkSiteAddress from "../../../../../form/common/components/dsfr-work-site/DsfrfWorkSiteAddress";
+import SingleCheckbox from "../../../../common/Components/SingleCheckbox/SingleCheckbox";
 
 const EmitterBsvhu = ({ errors }) => {
   const { siret } = useParams<{ siret: string }>();
@@ -124,7 +124,7 @@ const EmitterBsvhu = ({ errors }) => {
     <>
       {!!sealedFields.length && <DisabledParagraphStep />}
       <div className="fr-col-md-10 fr-mt-4w">
-        <Checkbox
+        <SingleCheckbox
           options={[
             {
               label: "Installation en situation irrégulière",
@@ -210,7 +210,7 @@ const EmitterBsvhu = ({ errors }) => {
 
         {emitter.irregularSituation && (
           <>
-            <Checkbox
+            <SingleCheckbox
               options={[
                 {
                   label: "L'installation n'a pas de numéro SIRET",

--- a/front/src/Apps/Dashboard/Validation/BSDD/SignOperation.tsx
+++ b/front/src/Apps/Dashboard/Validation/BSDD/SignOperation.tsx
@@ -24,7 +24,6 @@ import { datetimeToYYYYMMDD } from "../../../../common/datetime";
 import { subMonths } from "date-fns";
 import Button from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import CompanySelectorWrapper from "../../../common/Components/CompanySelectorWrapper/CompanySelectorWrapper";
 import RhfOperationModeSelect from "../../../common/Components/OperationModeSelect/RhfOperationModeSelect";
 import Select from "@codegouvfr/react-dsfr/Select";
@@ -32,6 +31,7 @@ import { toCompanyInput } from "../bsff/SignBsffPackagingForm";
 import Alert from "@codegouvfr/react-dsfr/Alert";
 import RhfExtraEuropeanCompanyManualInput from "../../Components/RhfExtraEuropeanCompanyManualInput/RhfExtraEuropeanCompanyManualInput";
 import CompanyContactInfo from "../../../../Apps/Forms/Components/RhfCompanyContactInfo/RhfCompanyContactInfo";
+import SingleCheckbox from "../../../common/Components/SingleCheckbox/SingleCheckbox";
 
 const MARK_AS_PROCESSED = gql`
   mutation MarkAsProcessed($id: ID!, $processedInfo: ProcessedFormInput!) {
@@ -390,7 +390,7 @@ function SignOperationModal({
         {isGroupement && noTraceability !== null && (
           <div className="fr-grid-row fr-grid-row--gutters">
             <div className="fr-col-12 fr-pb-0">
-              <Checkbox
+              <SingleCheckbox
                 options={[
                   {
                     label:
@@ -459,7 +459,7 @@ function SignOperationModal({
             </div>
             <div className="fr-grid-row fr-grid-row--gutters">
               <div className="fr-col-12">
-                <Checkbox
+                <SingleCheckbox
                   options={[
                     {
                       label: "L'entreprise est située hors UE",

--- a/front/src/Apps/Dashboard/Validation/BSPaoh/WorkflowAction/components/PackagingAcceptationWidget.tsx
+++ b/front/src/Apps/Dashboard/Validation/BSPaoh/WorkflowAction/components/PackagingAcceptationWidget.tsx
@@ -1,11 +1,10 @@
-import { Checkbox } from "@codegouvfr/react-dsfr/Checkbox";
-
 import React, { useEffect, useReducer } from "react";
 
 import {
   getVerbosePackagingType,
   getVerboseConsistence
 } from "../../paohUtils";
+import SingleCheckbox from "../../../../../common/Components/SingleCheckbox/SingleCheckbox";
 const SET_ACCEPTATION = "set_acceptation";
 const SET_ACCEPTATIONS = "set_acceptations";
 
@@ -88,7 +87,7 @@ export const PackagingAcceptationWidget = ({
             <th>Consistance</th>
             <th>Codes d'id.</th>
             <th>
-              <Checkbox
+              <SingleCheckbox
                 options={[
                   {
                     label: "",
@@ -123,7 +122,7 @@ export const PackagingAcceptationWidget = ({
               <td>{getVerboseConsistence(p.consistence)}</td>
               <td>{p.identificationCodes.join(",")}</td>
               <td>
-                <Checkbox
+                <SingleCheckbox
                   options={[
                     {
                       label: "",

--- a/front/src/Apps/Dashboard/Validation/bsff/SignBsffPackagingForm.tsx
+++ b/front/src/Apps/Dashboard/Validation/bsff/SignBsffPackagingForm.tsx
@@ -35,7 +35,6 @@ import NonScrollableInput from "../../../common/Components/NonScrollableInput/No
 import { datetimeToYYYYMMDD } from "../../../../common/datetime";
 import Decimal from "decimal.js";
 import { OPERATION } from "../../../../form/bsff/utils/constants";
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import RhfOperationModeSelect from "../../../common/Components/OperationModeSelect/RhfOperationModeSelect";
 import CompanySelectorWrapper from "../../../common/Components/CompanySelectorWrapper/CompanySelectorWrapper";
 import { useParams } from "react-router-dom";
@@ -43,6 +42,7 @@ import CompanyContactInfo from "../../../Forms/Components/RhfCompanyContactInfo/
 import { subMonths } from "date-fns";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
+import SingleCheckbox from "../../../common/Components/SingleCheckbox/SingleCheckbox";
 
 type SignBsffPackagingFormProps = {
   packaging: BsffPackaging & { bsff: Bsff };
@@ -658,7 +658,7 @@ function SignBsffPackagingForm({
               {isGroupement && (
                 <div className="fr-grid-row fr-grid-row--gutters">
                   <div className="fr-col-12">
-                    <Checkbox
+                    <SingleCheckbox
                       options={[
                         {
                           label: (

--- a/front/src/Apps/common/Components/SelectWithSubOptions/SelectWithSubOptions.tsx
+++ b/front/src/Apps/common/Components/SelectWithSubOptions/SelectWithSubOptions.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import "./selectWithSubOptions.scss";
 import {
   getLabel,
@@ -7,6 +6,7 @@ import {
   onSelectChange
 } from "./SelectWithSubOptions.utils";
 import { Option } from "../Select/Select";
+import SingleCheckbox from "../SingleCheckbox/SingleCheckbox";
 
 interface SelectWithSubOptions {
   selected: Option[];
@@ -23,11 +23,14 @@ const SelectWithSubOptions = ({
   const ref = useRef<React.ElementRef<"div"> | null>(null);
 
   // Close select if user clicks elsewhere in the page
-  const handleClickInPage = (e: MouseEvent) => {
-    if (ref.current && !ref.current.contains(e.target as Node)) {
-      if (isOpen) setIsOpen(false);
-    }
-  };
+  const handleClickInPage = useCallback(
+    (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        if (isOpen) setIsOpen(false);
+      }
+    },
+    [isOpen, ref]
+  );
   useEffect(() => {
     if (isOpen) {
       window.addEventListener("click", handleClickInPage);
@@ -52,8 +55,8 @@ const SelectWithSubOptions = ({
         return (
           <div className="fr-grid-row--gutters" key={optionPath}>
             <div>
-              <Checkbox
-                className={`optionCheckbox fr-ml-${ml * 8}v`}
+              <SingleCheckbox
+                className={`fr-ml-${ml * 8}v`}
                 options={[
                   {
                     label: option.label,

--- a/front/src/Apps/common/Components/SelectWithSubOptions/selectWithSubOptions.scss
+++ b/front/src/Apps/common/Components/SelectWithSubOptions/selectWithSubOptions.scss
@@ -31,5 +31,4 @@
 .optionCheckbox {
   margin: 0;
   padding: 0;
-  margin-bottom: 16px;
 }

--- a/front/src/Apps/common/Components/SingleCheckbox/SingleCheckbox.tsx
+++ b/front/src/Apps/common/Components/SingleCheckbox/SingleCheckbox.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Checkbox, { CheckboxProps } from "@codegouvfr/react-dsfr/Checkbox";
+
+const SingleCheckbox = (
+  props: CheckboxProps & React.RefAttributes<HTMLFieldSetElement>
+) => {
+  return (
+    <fieldset className="fr-fieldset">
+      <div className="fr-fieldset__content">
+        <Checkbox {...props} />
+      </div>
+    </fieldset>
+  );
+};
+
+export default SingleCheckbox;

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -16,11 +16,11 @@ import Table from "@codegouvfr/react-dsfr/Table";
 import Input from "@codegouvfr/react-dsfr/Input";
 import Alert from "@codegouvfr/react-dsfr/Alert";
 import Decimal from "decimal.js";
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import NonScrollableInput from "../../../../Apps/common/Components/NonScrollableInput/NonScrollableInput";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
 import Button from "@codegouvfr/react-dsfr/Button";
 import { mergePackagings } from "../../../../common/packagings";
+import SingleCheckbox from "../../../../Apps/common/Components/SingleCheckbox/SingleCheckbox";
 
 type Appendix2MultiSelectProps = {
   // Résultat de la query `appendixForms` executé
@@ -249,7 +249,7 @@ export default function Appendix2MultiSelect({
     const rows = rowsData.map(
       ({ form, checked, quantityAccepted, quantityLeft, quantityGrouped }) => {
         return [
-          <Checkbox
+          <SingleCheckbox
             options={[
               {
                 label: "",
@@ -357,7 +357,7 @@ export default function Appendix2MultiSelect({
 
     // En tête du tableau
     const headers = [
-      <Checkbox
+      <SingleCheckbox
         options={[
           {
             label: "",

--- a/front/src/form/registry/common/WasteCodeSelector.tsx
+++ b/front/src/form/registry/common/WasteCodeSelector.tsx
@@ -1,7 +1,6 @@
 import Alert from "@codegouvfr/react-dsfr/Alert";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
-import { Checkbox } from "@codegouvfr/react-dsfr/Checkbox";
 import { ALL_WASTES, ALL_WASTES_TREE } from "@td/constants";
 import clsx from "clsx";
 import React, { useMemo, useRef, useState } from "react";
@@ -11,6 +10,7 @@ import { capitalize } from "../../../common/helper";
 import { formatError } from "../builder/error";
 import { useMedia } from "../../../common/use-media";
 import { MEDIA_QUERIES } from "../../../common/config";
+import SingleCheckbox from "../../../Apps/common/Components/SingleCheckbox/SingleCheckbox";
 import "./WasteCodeSelector.scss";
 
 type WasteCode = {
@@ -118,7 +118,7 @@ export function WasteCodeSelector({
               ) : (
                 <div className="tw-flex tw-items-center tw-gap-2">
                   {multiple ? (
-                    <Checkbox
+                    <SingleCheckbox
                       options={[
                         {
                           label: `${node.code} - ${node.description}`,

--- a/front/src/login/Signup.tsx
+++ b/front/src/login/Signup.tsx
@@ -12,8 +12,8 @@ import routes from "../Apps/routes";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
-import { Checkbox } from "@codegouvfr/react-dsfr/Checkbox";
 import { PasswordInput } from "@codegouvfr/react-dsfr/blocks/PasswordInput";
+import SingleCheckbox from "../Apps/common/Components/SingleCheckbox/SingleCheckbox";
 import styles from "./Login.module.scss";
 
 import { SENDER_EMAIL } from "../common/config";
@@ -154,7 +154,7 @@ export default function Signup() {
         </div>
         <div className="fr-grid-row fr-mb-2w">
           <div className={`fr-col ${styles.resetFlexCol}`}>
-            <Checkbox
+            <SingleCheckbox
               options={[
                 {
                   label: "Je certifie avoir lu les conditions générales",


### PR DESCRIPTION
# Contexte

Pour passer node de v20 à v22, il y a eu un bump de react-dsfr de 1.20 à 1.26. Ca a introduit un problème avec les checkbox, qui sont parfois toutes collées les unes aux autres.
Ca arrive quand au lieu de mettre les checkbox dans "options" d'un composant checkbox, on crée plusieurs composants Checkbox les uns en dessous des autres (généralement parce qu'il faut mettre des sous-sections, donc pas possible de gérer ça avec un seul composant checkbox).

Le comportement était le même avant, mais entre temps a été introduit ce bout de code https://github.com/codegouvfr/react-dsfr/blob/4a94ba54823647663b137b02a3d9873470fdb366/src/shared/Fieldset.tsx#L148
Qui fait que si il y a qu'une seule checkbox, le composant FieldSet est omis pour wrapper le tout, et donc le CSS qui faisait les marges disparaît.

Je crée donc ici un composant "SingleCheckbox" qui réintroduit ce wrapper pourles checkbox isolées, et rétabli donc les marges/padding corrects, tout en ne faisant pas de conflit avec les checkbox groupées (ce qui aurait été le cas en cas d'utilisation de CSS global).

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB