### PR TITLE
[TRA-8924] BSDA - Consistance Pâteux

### DIFF
--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -107,6 +107,7 @@ export function expandBsdaFromDb(bsda: BsdaWithTransporters): GraphqlBsda {
       code: bsda.wasteCode,
       name: bsda.wasteMaterialName, // TODO To remove - keeps support for `name` for now
       consistence: bsda.wasteConsistence,
+      consistenceDescription: bsda.wasteConsistenceDescription,
       familyCode: bsda.wasteFamilyCode,
       materialName: bsda.wasteMaterialName,
       sealNumbers: bsda.wasteSealNumbers,
@@ -593,6 +594,7 @@ function flattenBsdaWasteInput({ waste }: Pick<BsdaInput, "waste">) {
     wasteMaterialName:
       chain(waste, w => w.materialName) ?? chain(waste, w => w.name),
     wasteConsistence: chain(waste, w => w.consistence),
+    wasteConsistenceDescription: chain(waste, w => w.consistenceDescription),
     wasteSealNumbers: undefinedOrDefault(
       chain(waste, w => w.sealNumbers),
       []

--- a/back/src/bsda/typeDefs/bsda.enums.graphql
+++ b/back/src/bsda/typeDefs/bsda.enums.graphql
@@ -70,6 +70,8 @@ enum BsdaConsistence {
   PULVERULENT
   "Autre"
   OTHER
+  "Pâteux"
+  PATEUX
 }
 
 "Type de signature apposée"

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -192,8 +192,10 @@ input BsdaWasteInput {
   familyCode: String
   "Nom usuel du matériau"
   materialName: String
-  "Consistence"
+  "Consistance"
   consistence: BsdaConsistence
+  "Détail de la consistance, dans le cas où la consistance est 'AUTRE'"
+  consistenceDescription: String
   "Numéros de scellés"
   sealNumbers: [String!]
   "Si le déchet est soumis à l'ADR ou non"

--- a/back/src/bsda/typeDefs/bsda.objects.graphql
+++ b/back/src/bsda/typeDefs/bsda.objects.graphql
@@ -162,6 +162,8 @@ type BsdaWaste {
   materialName: String
   "Consistence"
   consistence: BsdaConsistence
+  "Détail de la consistance, dans le cas où la consistance est 'AUTRE'"
+  consistenceDescription: String
   "Numéros de scellés"
   sealNumbers: [String!]
   "Si le déchet est soumis à l'ADR ou non"

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -815,6 +815,11 @@ export const bsdaEditionRules: BsdaEditionRules = {
     required: { from: fromWorkOrEmissionWhenThereIsNoWorker },
     readableFieldName: "La consistance"
   },
+  wasteConsistenceDescription: {
+    sealed: { from: fromWorkOrEmissionWhenThereIsNoWorker },
+    required: { from: fromWorkOrEmissionWhenThereIsNoWorker },
+    readableFieldName: "La consistance"
+  },
   wasteSealNumbers: {
     readableFieldName: "Le(s) numéro(s) de scellés",
     sealed: { from: "WORK" }

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -146,6 +146,7 @@ export const rawBsdaSchema = z.object({
   wasteFamilyCode: z.string().nullish(),
   wasteMaterialName: z.string().nullish(),
   wasteConsistence: z.nativeEnum(BsdaConsistence).nullish(),
+  wasteConsistenceDescription: z.string().nullish(),
   wasteSealNumbers: z.array(z.string()).default([]),
   wasteIsSubjectToADR: z.boolean().nullish(),
   wasteAdr: z

--- a/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
+++ b/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
@@ -161,6 +161,7 @@ export const cloneBsda = async (user: Express.User, id: string) => {
     wasteNonRoadRegulationMention: bsda.wasteNonRoadRegulationMention,
     wasteCode: bsda.wasteCode,
     wasteConsistence: bsda.wasteConsistence,
+    wasteConsistenceDescription: bsda.wasteConsistenceDescription,
     wasteFamilyCode: bsda.wasteFamilyCode,
     wasteMaterialName: bsda.wasteMaterialName,
     wastePop: bsda.wastePop,

--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaWork.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaWork.tsx
@@ -383,10 +383,17 @@ const SignBsdaWork = ({ bsdaId, onClose }) => {
                     }
                   },
                   {
-                    label: "Pulvérulents",
+                    label: "Pulvérulent",
                     nativeInputProps: {
                       ...register("waste.consistence"),
                       value: BsdaConsistence.Pulverulent
+                    }
+                  },
+                  {
+                    label: "Pâteux",
+                    nativeInputProps: {
+                      ...register("waste.consistence"),
+                      value: BsdaConsistence.Pateux
                     }
                   },
                   {

--- a/front/src/form/bsda/stepper/steps/WasteInfo.tsx
+++ b/front/src/form/bsda/stepper/steps/WasteInfo.tsx
@@ -69,6 +69,8 @@ export function WasteInfo({ disabled }) {
 export function WasteInfoWorker({ disabled }) {
   const { values, setFieldValue } = useFormikContext<Bsda>();
   const isDechetterie = values?.type === "COLLECTION_2710";
+  const isOtherConsistence =
+    values?.waste?.consistence === BsdaConsistence.Other;
 
   return (
     <>
@@ -208,11 +210,26 @@ export function WasteInfoWorker({ disabled }) {
             disabled={disabled}
           >
             <option value={BsdaConsistence.Solide}>Solide</option>
-            <option value={BsdaConsistence.Pulverulent}>Pulvérulents</option>
+            <option value={BsdaConsistence.Pulverulent}>Pulvérulent</option>
+            <option value={BsdaConsistence.Pateux}>Pâteux</option>
             <option value={BsdaConsistence.Other}>Autre</option>
           </Field>
         </label>
       </div>
+
+      {isOtherConsistence && (
+        <div className="form__row">
+          <label>
+            Détail de la consistance
+            <Field
+              disabled={disabled}
+              type="text"
+              name="waste.consistenceDescription"
+              className="td-input"
+            />
+          </label>
+        </div>
+      )}
 
       <h4 className="form__section-heading">Quantité</h4>
       <div className="form__row">

--- a/libs/back/prisma/src/models/main.prisma
+++ b/libs/back/prisma/src/models/main.prisma
@@ -1709,6 +1709,7 @@ model Bsda {
   wasteFamilyCode               String?
   wasteMaterialName             String?
   wasteConsistence              BsdaConsistence?
+  wasteConsistenceDescription   String?
   wasteSealNumbers              String[]
   wasteIsSubjectToADR           Boolean?
   wasteAdr                      String?
@@ -2328,6 +2329,7 @@ enum BsdaType {
 enum BsdaConsistence {
   SOLIDE
   PULVERULENT
+  PATEUX
   OTHER
 }
 


### PR DESCRIPTION
# Contexte

Ajout de la consistance Pâteux sur le BSDA, et ajout d'un champ à remplir de manière optionelle pour le moment lorsqu'on saisi "autre"

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB