### PR TITLE
[TRA-17004] Le BSDA de collecte en déchetterie passe au statut Refusé à la signature de la réception si le déchet est refusé

### DIFF
--- a/back/src/bsda/machine.ts
+++ b/back/src/bsda/machine.ts
@@ -42,6 +42,10 @@ export const machine = createMachine<Record<string, never>, Event>(
               cond: "isCollectedBy2710AndGroupingOrReshipmentOperation"
             },
             {
+              target: BsdaStatus.REFUSED,
+              cond: "isCollectedBy2710AndRefused"
+            },
+            {
               target: BsdaStatus.RECEIVED,
               cond: "isCollectedBy2710"
             }
@@ -137,6 +141,10 @@ export const machine = createMachine<Record<string, never>, Event>(
         ),
       isCollectedBy2710: (_, event) =>
         event.bsda?.type === BsdaType.COLLECTION_2710,
+      isCollectedBy2710AndRefused: (_, event) =>
+        event.bsda?.type === BsdaType.COLLECTION_2710 &&
+        event.bsda?.destinationReceptionAcceptationStatus ===
+          BsdaStatus.REFUSED,
       isCollectedBy2710AndGroupingOrReshipmentOperation: (_, event) =>
         event.bsda?.type === BsdaType.COLLECTION_2710 &&
         !!event.bsda?.destinationOperationCode &&


### PR DESCRIPTION
# Contexte

Bugfix: quand on signe un BSDA de collecte en déchetterie, si le déchet a été refusé, le statut devrait passer à REFUSED

# Démo

[Screencast from 2025-08-29 17-43-20.webm](https://github.com/user-attachments/assets/5a707b3e-b290-42ec-9734-0146b1537564)

# Ticket Favro

[Passer le bordereau au statut Refusé dès que l'acceptation a été signée et ne pas permettre d'accéder à la modale de signature du traitement sur le BSDA de collecte en déchetterie](https://favro.com/widget/ab14a4f0460a99a9d64d4945/e00961fc16ef3114c2007f31?card=tra-17004&secret=hl4LVzfXY4oJts7miiLkR3WTfsqxUtxwJzvt6xy1zGD)