### PR TITLE
[TRA-16607] Correction de l'affichage du statut de signature émetteur dans l'Aperçu des BSVHU

### DIFF
--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -65,6 +65,7 @@ export function expandVhuFormFromDb(bsvhu: PrismaVhuForm): GraphqlVhuForm {
       agrementNumber: bsvhu.emitterAgrementNumber,
       irregularSituation: bsvhu.emitterIrregularSituation ?? false,
       noSiret: bsvhu.emitterNoSiret ?? false,
+      notOnTD: bsvhu.emitterNotOnTD ?? false,
       company: nullIfNoValues<FormCompany>({
         name: bsvhu.emitterCompanyName,
         siret: bsvhu.emitterCompanySiret,

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -99,6 +99,8 @@ type BsvhuEmitter {
   company: FormCompany
   "Déclaration générale de l'émetteur du bordereau"
   emission: BsvhuEmission
+  "Indique si l'émetteur est inscrit sur TD ou non"
+  notOnTD: Boolean!
 }
 
 type BsvhuEmission {

--- a/front/src/Apps/Dashboard/Preview/BSVHU/BSVHUPreviewEmitter.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSVHU/BSVHUPreviewEmitter.tsx
@@ -18,7 +18,6 @@ const BSVHUPreviewEmitter = ({ bsd }: BSVHUPreviewEmitterProps) => {
 
   // Uniquement pour les situations irrégulières
   const getIsSignedByEmitterLabel = (bsd: Bsvhu) => {
-    console.log("bsd.emitter?.notOnTD", bsd.emitter?.notOnTD);
     const isPublished = bsd.emitter?.emission?.signature?.date;
 
     // Situation régulière

--- a/front/src/Apps/Dashboard/Preview/BSVHU/BSVHUPreviewEmitter.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSVHU/BSVHUPreviewEmitter.tsx
@@ -16,6 +16,31 @@ interface BSVHUPreviewEmitterProps {
 const BSVHUPreviewEmitter = ({ bsd }: BSVHUPreviewEmitterProps) => {
   const isIrregularSituation = bsd.emitter?.irregularSituation;
 
+  // Uniquement pour les situations irrégulières
+  const getIsSignedByEmitterLabel = (bsd: Bsvhu) => {
+    console.log("bsd.emitter?.notOnTD", bsd.emitter?.notOnTD);
+    const isPublished = bsd.emitter?.emission?.signature?.date;
+
+    // Situation régulière
+    if (!isIrregularSituation) {
+      return isPublished ? "Oui" : null;
+    }
+
+    // L'émetteur est un SIRET en situation irrégulière inscrit sur Trackdéchets
+    if (bsd.emitter?.noSiret) {
+      return "Non";
+    }
+
+    // Non inscrit sur TD
+    if (bsd.emitter?.notOnTD) {
+      return "Non";
+    }
+    // Inscrit sur TD
+    else {
+      return isPublished ? "Oui" : null;
+    }
+  };
+
   return (
     <PreviewContainer>
       {isIrregularSituation && (
@@ -69,16 +94,10 @@ const BSVHUPreviewEmitter = ({ bsd }: BSVHUPreviewEmitterProps) => {
             value={bsd.emitter?.emission?.signature?.date}
           />
 
-          {isIrregularSituation && (
-            <PreviewTextRow
-              label="Signature de l'émetteur"
-              value={
-                bsd.emitter?.noSiret || !bsd.emitter?.company?.siret
-                  ? "Oui"
-                  : "Non"
-              }
-            />
-          )}
+          <PreviewTextRow
+            label="Signature de l'émetteur"
+            value={getIsSignedByEmitterLabel(bsd)}
+          />
         </PreviewContainerCol>
       </PreviewContainerRow>
     </PreviewContainer>

--- a/front/src/Apps/common/queries/fragments/bsvhu.ts
+++ b/front/src/Apps/common/queries/fragments/bsvhu.ts
@@ -125,6 +125,7 @@ export const FullBsvhuFragment = gql`
       agrementNumber
       irregularSituation
       noSiret
+      notOnTD
       emission {
         signature {
           author


### PR DESCRIPTION
# Contexte

Le champ "Signé par l'émetteur" n'était pas correctement renseigné selon les cas de figure.

<img width="2510" height="1358" alt="image" src="https://github.com/user-attachments/assets/577c21f3-885c-4cf2-bd21-7f3b85dbfea6" />

# Ticket Favro

[Remonter correctement le champ Signature de l'émetteur sur l'aperçu du VHU](https://favro.com/widget/ab14a4f0460a99a9d64d4945/e00961fc16ef3114c2007f31?card=tra-16607&secret=hl4LVzfXY4oJts7miiLkR3WTfsqxUtxwJzvt6xy1zGD)
