### PR TITLE
[TRA 16935] Ne pas faire apparaître deux fois le code R4 dans la modale de traitement VHU

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuOperation.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuOperation.tsx
@@ -170,7 +170,7 @@ const SignVhuOperation = ({ bsvhuId, onClose }) => {
     }
   }, [operationCode, setValue]);
 
-  const onSubmit = async data => {
+  const onSubmit = async (data: ZodBsvhuOperation) => {
     const { author, date, ...update } = data;
     await updateBsvhu({
       variables: {
@@ -220,30 +220,22 @@ const SignVhuOperation = ({ bsvhuId, onClose }) => {
             }
           >
             <option value="">Sélectionnez une valeur...</option>
-            {!dataCompany?.companyPrivateInfos?.wasteVehiclesTypes?.includes(
-              WasteVehiclesType.Broyeur
-            ) && (
-              <option value="R 4">
-                R 4 - Recyclage ou récupération des métaux et des composés
-                métalliques
-              </option>
-            )}
+
+            <option value="R 4">
+              R 4 - Recyclage ou récupération des métaux et des composés
+              métalliques
+            </option>
+
             {(dataCompany?.companyPrivateInfos?.wasteVehiclesTypes?.includes(
               WasteVehiclesType.Broyeur
             ) ||
               dataCompany?.companyPrivateInfos?.wasteVehiclesTypes?.includes(
                 WasteVehiclesType.Demolisseur
               )) && (
-              <>
-                <option value="R 4">
-                  R 4 - Recyclage ou récupération des métaux et des composés
-                  métalliques
-                </option>
-                <option value="R 12">
-                  R 12 - Échange de déchets en vue de les soumettre à l'une des
-                  opérations numérotées R1 à R11
-                </option>
-              </>
+              <option value="R 12">
+                R 12 - Échange de déchets en vue de les soumettre à l'une des
+                opérations numérotées R1 à R11
+              </option>
             )}
           </Select>
 


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Ne pas faire apparaître en double le code de traitement R4 dans la liste des codes d'opération lorsque la destination a le type de profil Démolisseur uniquement

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

<img width="1157" height="399" alt="image" src="https://github.com/user-attachments/assets/22b5ccdd-04e4-4599-bd5c-9ea67574540b" />
(l'est beau mon screenshot, hein ?)

# Ticket Favro

[Ne pas faire apparaître en double le code de traitement R4 dans la liste des codes d'opération lorsque la destination a le type de profil Démolisseur uniquement](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16935)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB