### PR TITLE
[tra-16890]Compléter par défaut la timeline lorsque l'émetteur est un particulier sur les modales de signature BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsda/BsdaJourneySummary.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/BsdaJourneySummary.tsx
@@ -12,7 +12,11 @@ interface Props {
 }
 
 export function BsdaJourneySummary({ bsda }: Props) {
-  const signedByEmitter = Boolean(bsda.emitter?.emission?.signature?.date);
+  const signedByEmitter =
+    Boolean(bsda.emitter?.emission?.signature?.date) ||
+    (bsda.emitter?.isPrivateIndividual &&
+      !bsda.isDraft &&
+      bsda.status !== "INITIAL");
   const workerIsDisabled = bsda.worker?.isDisabled;
   const signedByWorker = Boolean(bsda.worker?.work?.signature?.date);
 


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->
<img width="664" height="629" alt="Screenshot 2025-09-02 at 18 33 32" src="https://github.com/user-attachments/assets/c15537f7-90e3-496d-b3b5-dcf1df278eaa" />
<img width="657" height="604" alt="Screenshot 2025-09-02 at 18 31 03" src="https://github.com/user-attachments/assets/c81866a8-2bac-4605-9f64-a8bfde8e21c3" />
<img width="693" height="622" alt="Screenshot 2025-09-02 at 18 30 07" src="https://github.com/user-attachments/assets/904d2edd-30d4-499d-b73a-d6cbdb4d3a8f" />

# Ticket Favro

[tra-16890](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16890)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB