### PR TITLE
[TRA 16931] Retirer message d'erreur en double

### DIFF
--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
@@ -221,11 +221,6 @@ const WasteBsvhu = ({
           label="Détail des identifications"
           fieldName="identification.numbers"
         />
-        {formState.errors.identification?.numbers?.message && (
-          <p className="fr-text fr-error-text">
-            {formState.errors.identification?.numbers?.message}
-          </p>
-        )}
       </div>
 
       <h4 className="fr-h4">Quantité remise</h4>


### PR DESCRIPTION
# Contexte

Le message d'erreur "Les numéros d'identification est un champ requis" apparaissait en double sur le formulaire BSVHU ca il est déjà géré en interne dans le ccomposant du champ, et était aussi affiché en dessous. J'enlève donc le message affiché en dessous qui est redondant.

# Points de vigilance pour les intégrateurs

X

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Ne pas afficher deux fois le message d'erreur "Les numéros d'identification est un champ requis." à la publication d'un VHU si le champ est manquant](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16931)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB