### PR TITLE
[TRA 16961] Amélioration du zoom de la carte des parcelles pour éviter la confusion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Suppression du message d'erreur en double sur les numéros d'identification dans le formulaire BSVHU [PR 4400](https://github.com/MTES-MCT/trackdechets/pull/4400)
+- Amélioration du zoom de la carte des parcelles pour éviter la confusion [PR 4401](https://github.com/MTES-MCT/trackdechets/pull/4401)
 
 #### :boom: Breaking Change
 

--- a/front/src/form/registry/common/ParcelsVisualizer/ParcelsVisualizer.tsx
+++ b/front/src/form/registry/common/ParcelsVisualizer/ParcelsVisualizer.tsx
@@ -264,7 +264,7 @@ export function ParcelsVisualizer({
         }
         if (!isEmptyExtent(globalExtent)) {
           map.getView().fit(globalExtent, {
-            maxZoom: onlyCoordinates ? 7.9 : 9,
+            maxZoom: onlyCoordinates ? 7.5 : 9,
             padding: [50, 50, 50, 50]
           });
         }

--- a/front/src/form/registry/common/ParcelsVisualizer/ParcelsVisualizer.tsx
+++ b/front/src/form/registry/common/ParcelsVisualizer/ParcelsVisualizer.tsx
@@ -198,6 +198,9 @@ export function ParcelsVisualizer({
         let map: Map;
         let markerLayerId: string;
         let parcelLayerId: string;
+        // ths flag is used to change how we fit the map, depending if there are only coordinates
+        // or if there are also parcels. Zooming too much when there are only coordinates can lead to
+        // confusing maps or even issues (whhite map) when the coordinate is outside France.
         let onlyCoordinates = true;
         try {
           const res = createMap();

--- a/front/src/form/registry/common/ParcelsVisualizer/ParcelsVisualizer.tsx
+++ b/front/src/form/registry/common/ParcelsVisualizer/ParcelsVisualizer.tsx
@@ -198,6 +198,7 @@ export function ParcelsVisualizer({
         let map: Map;
         let markerLayerId: string;
         let parcelLayerId: string;
+        let onlyCoordinates = true;
         try {
           const res = createMap();
           map = res.map;
@@ -217,6 +218,7 @@ export function ParcelsVisualizer({
         setParcelLayerId(parcelLayerId);
         let globalExtent = createEmptyExtent();
         if (inseeCodeValues.length > 0) {
+          onlyCoordinates = false;
           for (let i = 0; i < inseeCodeValues.length; i++) {
             const inseeCode = inseeCodeValues[i];
             const number = numberValues[i];
@@ -262,6 +264,7 @@ export function ParcelsVisualizer({
         }
         if (!isEmptyExtent(globalExtent)) {
           map.getView().fit(globalExtent, {
+            maxZoom: onlyCoordinates ? 7.9 : 9,
             padding: [50, 50, 50, 50]
           });
         }


### PR DESCRIPTION
# Contexte

Lors de l'ouverture pour modification d'une déclaration TEXS où il y a la carte des parcelles, si il y a déjà des parcelles/coordonnées sélectionnées, la carte se zoom pour afficher l'ensemble des sélections.

2 petits soucis d'affichage liés à ça:
- une coordonnée peut être au milieu d'un océan. Dans ce cas la carte va zoomer sur l'océan, mais les cartes géoportail n'ont pas le même niveau de définition en dehors de la France. Les carreaux ne s'affichent pas lorsque le zoom est trop important dans ces zones hors-France, donc la carte apparaît blanche, ce qui est un peu désorientant
- une coordonnée seule au milieu d'un champ avec un zoom très important peut aussi être un peu désorientante

Pour régler ces soucis, j'ajoute un zoom maximum lors de ce focus initial. Je mets un zoom différent selon si il y a uniquement des coordonnées (qui peuvent donc être au mileu de la mer) pour ne pas dépasser le zoom maximum hors France. Je mets un zoom un peu plus important si il y a des parcelles, parce que celà veut dire que l'on est en zone France, donc que la carte peut accepter plus de zoom, tout en restant suffisamment loin pour ne pas être perdu dans un champ.

# Points de vigilance pour les intégrateurs

X

# Démo

### Coordonnée dans l'océan

Avant

<img width="1000" height="699" alt="Capture d’écran 2025-09-03 à 04 10 27" src="https://github.com/user-attachments/assets/a56a43e6-f01d-4f14-b4bb-d06919ab7468" />

Après

<img width="998" height="680" alt="Capture d’écran 2025-09-03 à 04 07 29" src="https://github.com/user-attachments/assets/9ccd1f6b-eaab-4dfd-9652-c5e0d9cc8902" />

### Coordonnée dans les champs

Avant

<img width="994" height="692" alt="Capture d’écran 2025-09-03 à 04 09 04" src="https://github.com/user-attachments/assets/d4b64d21-d867-4526-883e-7e17a2b04c4b" />


Après

<img width="999" height="690" alt="Capture d’écran 2025-09-03 à 04 09 18" src="https://github.com/user-attachments/assets/25df7942-44c9-45f7-afba-acde890dc5e8" />


# Ticket Favro

[La carte ne s'affiche pas correctement lorsque je vais pour procéder à la modification d'une déclaration pour laquelle les parcelles sont valorisées (TEXS sortants)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16961)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB