### PR TITLE
[TRA 16884] déplacement des champs de transfert transfrontalier sur IHM Registre DND entrant

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 # [2025.09.1] 23/09/2025
 
+#### :nail_care: Améliorations
+
+- Déplacement des champs de transfert transfrontalier sur IHM Registre DND entrant [PR 4403](https://github.com/MTES-MCT/trackdechets/pull/4403)
+
 #### :bug: Corrections de bugs
 
 - Suppression du message d'erreur en double sur les numéros d'identification dans le formulaire BSVHU [PR 4400](https://github.com/MTES-MCT/trackdechets/pull/4400)

--- a/front/src/form/registry/incomingWaste/shape.ts
+++ b/front/src/form/registry/incomingWaste/shape.ts
@@ -187,6 +187,30 @@ export const incomingWasteFormShape: FormShape = [
           "initialEmitterCompanyCountryCode",
           "initialEmitterMunicipalitiesInseeCodes"
         ]
+      },
+      {
+        name: "ttdImportNumber",
+        shape: "generic",
+        title: "Transfert transfrontalier de déchets",
+        label: Labels.ttdImportNumber,
+        infoLabel: InfoLabels.gistrid,
+        required: true,
+        validation: {
+          ttdImportNumber: optionalString
+        },
+        type: "text",
+        style: { className: "fr-col-md-10" }
+      },
+      {
+        name: "movementNumber",
+        shape: "generic",
+        label: Labels.movementNumber,
+        required: true,
+        validation: {
+          movementNumber: optionalString
+        },
+        type: "text",
+        style: { className: "fr-col-md-10" }
       }
     ]
   },
@@ -347,29 +371,6 @@ export const incomingWasteFormShape: FormShape = [
           nextOperationCode: optionalString
         },
         shape: "custom"
-      },
-      {
-        name: "ttdImportNumber",
-        shape: "generic",
-        label: Labels.ttdImportNumber,
-        infoLabel: InfoLabels.gistrid,
-        required: true,
-        validation: {
-          ttdImportNumber: optionalString
-        },
-        type: "text",
-        style: { className: "fr-col-md-10" }
-      },
-      {
-        name: "movementNumber",
-        shape: "generic",
-        label: Labels.movementNumber,
-        required: true,
-        validation: {
-          movementNumber: optionalString
-        },
-        type: "text",
-        style: { className: "fr-col-md-10" }
       }
     ]
   },


### PR DESCRIPTION
# Contexte

Simple déplacement de champs pour être cohérent avec le registre TEXS entrant.

# Points de vigilance pour les intégrateurs

X

# Démo

<img width="1167" height="770" alt="Capture d’écran 2025-09-03 à 17 19 42" src="https://github.com/user-attachments/assets/43475bc5-5dc7-4a50-87a7-927fcd489949" />

# Ticket Favro

[Déplacer les champs liés au transfert transfrontalier dans l'onglet Producteur du registre D(N)D entrants](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16884)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB