### PR TITLE
Mod/filter otel

### DIFF
--- a/otel/collector-config.sec-fr1.yaml
+++ b/otel/collector-config.sec-fr1.yaml
@@ -48,7 +48,7 @@ processors:
         - 'resource.attributes["service.name"] == "nginx"'
         - 'resource.attributes["service.name"] == "metabase"'
         - 'resource.attributes["service.name"] == "trackdechets-api"'
-        - 'resource.attributes["service.name"] == "api" and log.attributes["request_timing"] == "start"'
+        - 'resource.attributes["service.name"] == "api" and attributes["request_timing"] == "start"'
 
 connectors:
   datadog/connector:

--- a/otel/collector-config.sec-fr1.yaml
+++ b/otel/collector-config.sec-fr1.yaml
@@ -40,6 +40,16 @@ processors:
       - key: db.statement
         action: delete
 
+  filter/log:
+    error_mode: ignore
+    logs:
+      log_record:
+        - 'resource.attributes["service.name"] == "nodejs"'
+        - 'resource.attributes["service.name"] == "nginx"'
+        - 'resource.attributes["service.name"] == "metabase"'
+        - 'resource.attributes["service.name"] == "trackdechets-api"'
+        - 'resource.attributes["service.name"] == "api" and log.attributes["request_timing"] == "start"'
+
 connectors:
   datadog/connector:
     traces:
@@ -82,5 +92,5 @@ service:
       exporters: [datadog/exporter]
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, batch/datadog_generic]
+      processors: [memory_limiter, filter/log, batch/datadog_generic]
       exporters: [datadog/exporter]


### PR DESCRIPTION
On déplace les filtres qui étaient au niveau de datadog vers le collecteur Otel pour éviter les problèmes de surcout sur les ingested logs.
En gros ca devrait diviser par 2 les logs ingérés, et ne rien changer aux indexés