### PR TITLE
fix: removing blank page from PDFs

### DIFF
--- a/back/src/common/pdf/assets/styles.css
+++ b/back/src/common/pdf/assets/styles.css
@@ -21,40 +21,24 @@ body {
 body:before {
   content: "";
   position: fixed;
-  inset: -60px 0 0 -60px;
-  font-size: 120px;
-  font-weight: bold;
-  display: grid;
-  justify-content: center;
-  align-content: center;
+  top: calc(50% + 0.25rem + 10px);
+  left: calc(50% + 0.25rem + 10px);
+  width: 100vw;
+  height: 100vh;
   opacity: 0.1;
-  transform: rotate(-45deg);
+  transform: translate(-50%, -50%) rotate(-45deg);
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: 800px 400px;
 }
 body.sandbox:before {
-  content: "SANDBOX";
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Ctext x='200' y='75' font-family='Arial' font-size='60' font-weight='bold' fill='%23161c4e' text-anchor='middle' dominant-baseline='middle'%3ESANDBOX%3C/text%3E%3Ctext x='200' y='115' font-family='Arial' font-size='30' font-weight='bold' fill='%23161c4e' text-anchor='middle' dominant-baseline='middle'%3EBordereau test%3C/text%3E%3C/svg%3E");
 }
 body.recette:before {
-  content: "RECETTE";
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Ctext x='200' y='75' font-family='Arial' font-size='60' font-weight='bold' fill='%23161c4e' text-anchor='middle' dominant-baseline='middle'%3ERECETTE%3C/text%3E%3Ctext x='200' y='115' font-family='Arial' font-size='30' font-weight='bold' fill='%23161c4e' text-anchor='middle' dominant-baseline='middle'%3EBordereau test%3C/text%3E%3C/svg%3E");
 }
 body.local:before {
-  content: "LOCAL";
-}
-body.sandbox:after,
-body.recette:after,
-body.local:after {
-  content: "Bordereau test";
-}
-body:after {
-  content: "";
-  position: fixed;
-  inset: 60px 0 0 60px;
-  font-size: 60px;
-  font-weight: bold;
-  display: grid;
-  justify-content: center;
-  align-content: center;
-  opacity: 0.1;
-  transform: rotate(-45deg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200' viewBox='0 0 400 200'%3E%3Ctext x='200' y='75' font-family='Arial' font-size='60' font-weight='bold' fill='%23161c4e' text-anchor='middle' dominant-baseline='middle'%3ELOCAL%3C/text%3E%3Ctext x='200' y='115' font-family='Arial' font-size='30' font-weight='bold' fill='%23161c4e' text-anchor='middle' dominant-baseline='middle'%3EBordereau test%3C/text%3E%3C/svg%3E");
 }
 
 h1,


### PR DESCRIPTION
# Contexte

Une page blanche se glisse à la fin des PDFs depuis la [feature de watermark](https://github.com/MTES-MCT/trackdechets/pull/4338).

Le problème vient des sélecteurs CSS. La feature en a introduit 2:
- Un `::before` qui sert à afficher en gros "LOCAL", "RECETTE" ou "SANDBOX"
- Un `::after` qui sert à afficher en petit "Bordereau test".

L'utilisation des 2 sélecteurs est à priori obligatoire puisqu'il est impossible, dans le content d'un seul sélecteur, d'appliquer des styles différents (notamment des tailles de polices différentes).

Mais le souci c'est que le sélecteur `::after` génère une page supplémentaire. 

Pour palier au problème, je l'ai supprimé. Mais comme on ne peut pas utiliser 2 styles différents dans le `::before`, je n'affiche plus du texte pour le content, mais une SVG. C'est le SVG qui s'occupe d'appliquer des styles différents au "gros titre" et au "petit titre".

Le rendu visuel est le même, mais on n'utilise plus qu'un seul sélecteur, `::before`.

# Démo

<img width="804" height="1020" alt="image" src="https://github.com/user-attachments/assets/e0b08fff-16ba-4e4c-a1b7-86accd489058" />

# Ticket Favro

[Une page blanche s’ajoute systématiquement aux récépissés PDF des BSD](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-17033)