### PR TITLE
[Yogosha 30068] Un membre lambda d'une entreprise ne peut pas refuser une demande de droits d'admin

### DIFF
--- a/back/src/adminRequest/resolvers/mutations/utils/refuseAdminRequest.utils.ts
+++ b/back/src/adminRequest/resolvers/mutations/utils/refuseAdminRequest.utils.ts
@@ -71,6 +71,19 @@ export const checkCanRefuseAdminRequest = async (
       "Vous n'êtes pas autorisé à effectuer cette action."
     );
   }
+
+  // A company admin can always refuse a request
+  if (companyAssociation.role === UserRole.ADMIN) {
+    return true;
+  }
+
+  // User must be targeted by the request
+  if (
+    user.id !== adminRequest.userId &&
+    user.id !== adminRequest.collaboratorId
+  ) {
+    throw new UserInputError(`Demande non valide.`);
+  }
 };
 
 export const sendEmailToCompanyAdmins = async (


### PR DESCRIPTION
# Contexte

Bug remonté sur Yogosha. N'importe quel membre d'une entreprise peut refuser une demande de droits d'admin.

Maintenant, seul un admin, ou un collaborateur ciblé par la demande peuvent refuser.

# Ticket Favro

[Driver(Reader) user is able to reject admin request to join a company #30068](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-17082)
