### PR TITLE
[TRA-17049] ETQ chauffeur, je peux signer un BSVHU avec émetteur en situation irrégulière et sans SIRET 

### DIFF
--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -500,6 +500,20 @@ export const getIsNonDraftLabel = (
   const isFollowTab = bsdCurrentTab === "followTab";
   const isToCollectTab = bsdCurrentTab === "toCollectTab";
 
+  // Si l'utilisateur est un chauffeur, il doit pouvoir signer un VHU
+  // en situation irrégulière (pas de siret émetteur)
+  const isTransporter = isSameSiretTransporter(currentSiret, bsd);
+  if (
+    isBsvhu(bsd.type) &&
+    isToCollectTab &&
+    isTransporter &&
+    permissions.includes(UserPermission.BsdCanSignTransport) &&
+    bsd.emitter?.irregularSituation &&
+    bsd.emitter?.noSiret
+  ) {
+    return SIGNER;
+  }
+
   if (
     isBsda(bsd.type) &&
     isCollection_2710(bsd.bsdWorkflowType?.toString()) &&


### PR DESCRIPTION
# Contexte

Dans le cas particulier d'un VHU en situation irrégulière et sans SIRET émetteur, le bouton "Signer" n'apparaît pas dans le front.

# Démo (du bug)

<img width="2866" height="644" alt="image" src="https://github.com/user-attachments/assets/458f8ad3-2711-43a5-9ef2-d3d444e6b56b" />

# Ticket Favro

[ETQ chauffeur, je ne peux pas signer le BSVHU lorsque l'émetteur est situation irrégulière et sans SIRET](https://favro.com/widget/ab14a4f0460a99a9d64d4945/e00961fc16ef3114c2007f31?card=tra-17049&secret=hl4LVzfXY4oJts7miiLkR3WTfsqxUtxwJzvt6xy1zGD)