### PR TITLE
[TRA-17032] Permettre de réviser le Nom de chantier ou de collecte sur le BSDA initial et BSDA de collecte en déchèterie

### DIFF
--- a/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
+++ b/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
@@ -124,26 +124,28 @@ export const mapRevision = (
     details: [
       {
         dataName: DataNameEnum.ADRESS_COLLECT,
-        dataOldValue: review?.[bsdName]?.emitter?.pickupSite?.address ||
-        review?.[bsdName]?.emitter?.pickupSite?.postalCode ||
-        review?.[bsdName]?.emitter?.pickupSite?.city ||
-        review?.[bsdName]?.emitter?.pickupSite?.infos
-          ? `${review?.[bsdName]?.emitter?.pickupSite?.address}, ${
-              review?.[bsdName]?.emitter?.pickupSite?.postalCode
-            } ${review?.[bsdName]?.emitter?.pickupSite?.city} ${
-              review?.[bsdName]?.emitter?.pickupSite?.infos ?? ""
-            }`
-          : "Non renseigné",
-        dataNewValue: review?.content?.emitter?.pickupSite?.address ||
-        review?.content?.emitter?.pickupSite?.postalCode ||
-        review?.content?.emitter?.pickupSite?.city ||
-        review?.content?.emitter?.pickupSite?.infos
-          ? `${review?.content?.emitter?.pickupSite?.address}, ${
-              review?.content?.emitter?.pickupSite?.postalCode
-            } ${review?.content?.emitter?.pickupSite?.city} ${
-              review?.content?.emitter?.pickupSite?.infos ?? ""
-            }`
-          : ""
+        dataOldValue:
+          review?.[bsdName]?.emitter?.pickupSite?.address ||
+          review?.[bsdName]?.emitter?.pickupSite?.postalCode ||
+          review?.[bsdName]?.emitter?.pickupSite?.city ||
+          review?.[bsdName]?.emitter?.pickupSite?.infos
+            ? `${review?.[bsdName]?.emitter?.pickupSite?.address}, ${
+                review?.[bsdName]?.emitter?.pickupSite?.postalCode
+              } ${review?.[bsdName]?.emitter?.pickupSite?.city} ${
+                review?.[bsdName]?.emitter?.pickupSite?.infos ?? ""
+              }`
+            : "Non renseigné",
+        dataNewValue:
+          review?.content?.emitter?.pickupSite?.address ||
+          review?.content?.emitter?.pickupSite?.postalCode ||
+          review?.content?.emitter?.pickupSite?.city ||
+          review?.content?.emitter?.pickupSite?.infos
+            ? `${review?.content?.emitter?.pickupSite?.address}, ${
+                review?.content?.emitter?.pickupSite?.postalCode
+              } ${review?.content?.emitter?.pickupSite?.city} ${
+                review?.content?.emitter?.pickupSite?.infos ?? ""
+              }`
+            : ""
       },
       {
         dataName: DataNameEnum.NAME_COLLECT,

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
@@ -117,7 +117,6 @@ export function BsdaRequestRevision({ bsda }: Props) {
 
   const onSubmitForm = async (data: ValidationSchema) => {
     const { comment, ...content } = data;
-    console.log(content);
     const cleanedContent = removeEmptyKeys(
       checkIfInitialObjectValueChanged(content)
     );


### PR DESCRIPTION
Permettre de réviser le Nom de chantier ou de collecte sur le BSDA initial et BSDA de collecte en déchèterie

# Contexte

**Environnement et bordereaux et/ou registres concernés**
- BSDA initial et de collecte en déchetterie

**En tant que**, acteur visé sur un BSDA (initial et de collecte en déchèterie),
**Je souhaite**, que le champ Nom de chantier apparaisse sur la modale de révision, 
**Afin de**, pouvoir réviser le nom de chantier du bordereau, au même titre que l'adresse de chantier. 

# Démo

<img width="1005" height="501" alt="image" src="https://github.com/user-attachments/assets/b4b45ac9-31cf-46cc-851f-a7a4b52dc810" />

<img width="561" height="301" alt="image" src="https://github.com/user-attachments/assets/b2550f29-94e2-41a7-9a68-c12836cc4842" />


# Ticket Favro

[TRA-17032](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-17032)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB