### PR TITLE
[TRA-16997] Afficher sur deux colonnes les conditionnements sur l'aperçu du BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Preview/BSDA/BSDAPreviewContent.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSDA/BSDAPreviewContent.tsx
@@ -143,7 +143,9 @@ const BSDAPreviewContent = ({ bsdId }: BSDAPreviewContentProps) => {
 
   const conditionnement = useMemo(
     () =>
-      bsd?.packagings ? getPackagingInfosSummary(bsd.packagings, true) : "",
+      bsd?.packagings
+        ? getPackagingInfosSummary(bsd.packagings, { hideDetails: true })
+        : "",
     [bsd]
   );
 

--- a/front/src/Apps/Dashboard/Preview/BSDA/BSDAPreviewWaste.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSDA/BSDAPreviewWaste.tsx
@@ -14,7 +14,10 @@ interface BSDAPreviewWasteProps {
 }
 const BSDAPreviewWaste = ({ bsd }: BSDAPreviewWasteProps) => {
   const conditionnement = useMemo(
-    () => (bsd?.packagings ? getPackagingInfosSummary(bsd.packagings) : ""),
+    () =>
+      bsd?.packagings
+        ? getPackagingInfosSummary(bsd.packagings, { expanded: true })
+        : "",
     [bsd]
   );
 
@@ -67,7 +70,7 @@ const BSDAPreviewWaste = ({ bsd }: BSDAPreviewWasteProps) => {
       </PreviewContainerRow>
 
       <PreviewContainerRow title={"Conditionnement"} separator>
-        <PreviewContainerCol gridWidth={10}>
+        <PreviewContainerCol gridWidth={12}>
           <PreviewTextRow label="Conditionnement" value={conditionnement} />
         </PreviewContainerCol>
       </PreviewContainerRow>

--- a/front/src/Apps/Dashboard/Preview/BSDPreviewComponents.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSDPreviewComponents.tsx
@@ -89,7 +89,7 @@ export const PreviewTextRow = ({
   units?: string | undefined | null;
 }) => {
   return (
-    <div className="fr-mb-1w">
+    <div className="fr-mb-1w" style={{ whiteSpace: "pre-wrap" }}>
       <div>
         {label}
         {tooltip ? <Tooltip title={tooltip} className="fr-ml-1v" /> : null}

--- a/front/src/Apps/common/utils/packagingsBsddSummary.ts
+++ b/front/src/Apps/common/utils/packagingsBsddSummary.ts
@@ -10,9 +10,13 @@ import { packagingTypeLabels } from "../../Forms/Components/PackagingList/helper
 
 // Renvoie un résumé des conditionnements de la forme suivante :
 // 7 colis : 2 Fûts de 50 litres (n° cont1, cont2), 5 GRVs de 1 litre (n° GRV1, GRV2, GRV3)
+// expanded a besoin que l'élément ait le style whiteSpace: "pre-wrap" pour gérer les sauts de ligne
 export function getPackagingInfosSummary<
   P extends PackagingInfo | BsdaPackaging
->(packagingInfos: P[], hideDetails?: boolean) {
+>(
+  packagingInfos: P[],
+  options?: { hideDetails?: boolean; expanded?: boolean }
+) {
   const total = packagingInfos.reduce(
     (acc, packagingInfo) => acc + packagingInfo.quantity,
     0
@@ -36,7 +40,9 @@ export function getPackagingInfosSummary<
               .join(" ")
           : packagingTypeLabels[packagingInfo.type];
 
-      let summary = `${packagingInfo.quantity} ${pluralize(
+      let summary = !!options?.expanded ? "- " : "";
+
+      summary += `${packagingInfo.quantity} ${pluralize(
         name,
         packagingInfo.quantity
       )}`;
@@ -53,13 +59,18 @@ export function getPackagingInfosSummary<
         summary += ` de ${volumeValue} ${volumeUnit}`;
       }
 
-      if (!hideDetails && packagingInfo.identificationNumbers?.length) {
+      if (
+        !options?.hideDetails &&
+        packagingInfo.identificationNumbers?.length
+      ) {
         summary += ` (n° ${packagingInfo.identificationNumbers.join(", ")})`;
       }
 
       return summary;
     })
-    .join(", ");
+    .join(!!options?.expanded ? "\n" : ", ");
 
-  return `${total} colis : ${packages}`;
+  return !!options?.expanded
+    ? `${total} colis :\n${packages}`
+    : `${total} colis : ${packages}`;
 }


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Afficher sur deux colonnes les conditionnements sur l'aperçu du BSDA

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

<img width="1699" height="1598" alt="image" src="https://github.com/user-attachments/assets/fd7bfa44-4dc0-47ad-b1bb-e732eff24f1f" />


# Ticket Favro

[Afficher sur deux colonnes les conditionnements sur l'aperçu du BSDA](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16997)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB