### PR TITLE
[TRA-17003] Compléter automatiquement le champ date avec la date d'aujourd'hui sur la modale de signature transporteur BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
@@ -131,7 +131,7 @@ const SignBsdaTransport = ({ bsdaId, onClose }) => {
       plates: signingTransporter?.transport?.plates ?? [],
       takenOverAt: signingTransporter?.transport?.takenOverAt
         ? datetimeToYYYYMMDD(new Date(signingTransporter.transport.takenOverAt))
-        : new Date().toISOString()
+        : datetimeToYYYYMMDD(TODAY)
     },
     signature: {
       author: "",
@@ -161,7 +161,7 @@ const SignBsdaTransport = ({ bsdaId, onClose }) => {
           ? datetimeToYYYYMMDD(
               new Date(signingTransporter.transport.takenOverAt)
             )
-          : new Date().toISOString()
+          : datetimeToYYYYMMDD(TODAY)
       },
       signature: {
         author: "",


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Compléter automatiquement le champ date avec la date d'aujourd'hui sur la modale de signature transporteur

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->
<img width="1699" height="1598" alt="image" src="https://github.com/user-attachments/assets/d5a44b29-a433-4fea-b5a0-61129c87e460" />


# Ticket Favro

[Compléter automatiquement le champ date avec la date d'aujourd'hui sur la modale de signature transporteur](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-17003)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB