### PR TITLE
[TRA-16999] Affichage des informations du prochain transporteur dans le cas de multimodal dans la modale de signature transport BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
@@ -120,7 +120,7 @@ const SignBsdaTransport = ({ bsdaId, onClose }) => {
   const TODAY = useMemo(() => new Date(), []);
 
   const signingTransporter = useMemo(
-    () => data?.bsda?.transporters?.find(t => !t.transport?.signature?.date),
+    () => data?.bsda?.transporters?.find(t => !t.transport?.signature),
     [data?.bsda]
   );
 


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Modifier les informations de contact de la modale de signature transporteur par celles du transporteur en cours et non du précédent en cas de multimodal 

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

<img width="1699" height="1598" alt="image" src="https://github.com/user-attachments/assets/6eac2812-f7bb-4093-920a-16e9726eb571" />


# Ticket Favro

[Modifier les informations de contact de la modale de signature transporteur par celles du transporteur en cours et non du précédent en cas de multimodal ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16999)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB