### PR TITLE
[TRA-16915] Remonter correctement la raison sociale du producteur de VHU en situation irrégulière

### DIFF
--- a/front/src/Apps/Dashboard/Preview/BSVHU/BSVHUPreviewEmitter.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSVHU/BSVHUPreviewEmitter.tsx
@@ -31,12 +31,14 @@ const BSVHUPreviewEmitter = ({ bsd }: BSVHUPreviewEmitterProps) => {
         <PreviewContainerCol gridWidth={3}>
           <PreviewTextRow
             label="Raison sociale"
-            value={isIrregularSituation ? "-" : bsd.emitter?.company?.name}
+            value={
+              bsd.emitter?.company?.siret ? bsd.emitter?.company?.name : "-"
+            }
           />
 
           <PreviewTextRow label="SIRET" value={bsd.emitter?.company?.siret} />
 
-          {isIrregularSituation && (
+          {isIrregularSituation && !bsd.emitter?.company?.siret && (
             <PreviewTextRow
               label="Nom ou identification de l'installation"
               value={bsd.emitter?.company?.name}


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Remonter correctement la Raison sociale du producteur en situation irrégulière, dans "Raison sociale" et non dans "Nom ou identification de l'installation"

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

<img width="1638" height="1353" alt="image" src="https://github.com/user-attachments/assets/3172f034-5abb-49f2-a04b-42e1bec954a3" />

<img width="1638" height="1353" alt="image" src="https://github.com/user-attachments/assets/cf5d201c-7cdd-47b6-8472-7ae067c3af78" />


# Ticket Favro

[Remonter correctement la Raison sociale du producteur en situation irrégulière, dans "Raison sociale" et non dans "Nom ou identification de l'installation"](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16915)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB