### PR TITLE
[TRA-16932] Afficher le code de traitement R12 pour les déchets * sur les VHU

### DIFF
--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
@@ -28,6 +28,7 @@ const WasteBsvhu = ({
   const containsElectricOrHybridVehicles = watch(
     "containsElectricOrHybridVehicles"
   );
+  const wasteCode = watch("wasteCode");
 
   const sealedFields = useContext(SealedFieldsContext);
 
@@ -64,6 +65,13 @@ const WasteBsvhu = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errors]);
+
+  useEffect(() => {
+    setValue(
+      "destination.plannedOperationCode",
+      wasteCode === "16 01 06" ? "R 4" : "R 12"
+    );
+  }, [setValue, wasteCode]);
 
   const identificationTypeOptions = [
     {


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Afficher par défaut le code de traitement R12 lorsque c'est le code déchet avec * qui a été sélectionné

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->


https://github.com/user-attachments/assets/c22837c2-6500-4240-9d1e-ee41a00ee6cf



# Ticket Favro

[Afficher par défaut le code de traitement R12 lorsque c'est le code déchet avec * qui a été sélectionné](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16932)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB