### PR TITLE
[Yogosha 30138] Retrait de l'endpoint /ip inutilisé avec une faille de sécurité potentielle

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -348,10 +348,6 @@ app.use(impersonateMiddleware);
 
 app.get("/ping", (_, res) => res.send("Pong!"));
 
-app.get("/ip", (req, res) => {
-  return res.send(`IP: ${req.ip} | XFF: ${req.get("X-Forwarded-For")}`);
-});
-
 app.get("/captcha", (_, res) => captchaGen(res));
 
 app.get("/captcha-audio/:tokenId", (req, res) => {


### PR DESCRIPTION
# Contexte

L'endpoint `/ip`, apparemment utilisé pour du débug, présente une faille de sécurité. On l'enlève.

# Ticket Favro

[[Yogosha 30138] Retrait de l'endpoint /ip inutilisé avec une faille de sécurité potentielle](https://favro.com/widget/ab14a4f0460a99a9d64d4945/e00961fc16ef3114c2007f31?card=tra-17104&secret=hl4LVzfXY4oJts7miiLkR3WTfsqxUtxwJzvt6xy1zGD)
