### PR TITLE
[Yogosha 30026] Mise à jour du rôle utilisateur en cache lors d'un changement par l'admin

### DIFF
--- a/back/src/users/resolvers/mutations/__tests__/changeUserRole.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/changeUserRole.integration.ts
@@ -12,12 +12,6 @@ import type { Mutation } from "@td/codegen-back";
 import { ErrorCode, NotCompanyAdminErrorMsg } from "../../../../common/errors";
 import { UserRole } from "@prisma/client";
 import { getDefaultNotifications } from "../../../notifications";
-import {
-  genUserRolesCacheKey,
-  getUserSessions
-} from "../../../../common/redis/users";
-import { app } from "../../../../server";
-import { logIn } from "../../../../__tests__/auth.helper";
 import { getUserRoles } from "../../../../permissions/permissions";
 
 const CHANGE_USER_ROLE = `

--- a/back/src/users/resolvers/mutations/changeUserRole.ts
+++ b/back/src/users/resolvers/mutations/changeUserRole.ts
@@ -26,6 +26,7 @@ import {
   updateUserAccountHash
 } from "../../database";
 import { getDefaultNotifications } from "../../notifications";
+import { deleteCachedUserRoles } from "../../../common/redis/users";
 
 const changeUserRoleResolver: MutationResolvers["changeUserRole"] = async (
   parent,
@@ -70,6 +71,10 @@ const changeUserRoleResolver: MutationResolvers["changeUserRole"] = async (
         `L'utilisateur n'est pas membre de l'entreprise`
       );
     }
+
+    // clear cache
+    await deleteCachedUserRoles(args.userId);
+
     return userAssociationToCompanyMember(
       updatedAssociation,
       company.orgId,

--- a/back/src/users/resolvers/mutations/changeUserRole.ts
+++ b/back/src/users/resolvers/mutations/changeUserRole.ts
@@ -72,15 +72,17 @@ const changeUserRoleResolver: MutationResolvers["changeUserRole"] = async (
       );
     }
 
-    // clear cache
-    await deleteCachedUserRoles(args.userId);
-
-    return userAssociationToCompanyMember(
+    const assocationToComp = await userAssociationToCompanyMember(
       updatedAssociation,
       company.orgId,
       user.id,
       isTDAdmin
     );
+
+    // Clear cache
+    await deleteCachedUserRoles(args.userId);
+
+    return assocationToComp;
   }
 
   const userAccountHash = await prisma.userAccountHash.findUnique({


### PR DESCRIPTION
# Contexte

Remonté dans un ticket Yogosha: quand un admin change le rôle d'un utilisateur, celui-ci met 10min à réellement changer. Ceci, à cause d'une cache Redis.

# Ticket Favro

[[Yogosha 30026] Mise à jour du rôle utilisateur en cache lors d'un changement par l'admin ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/e00961fc16ef3114c2007f31?card=tra-17111&secret=hl4LVzfXY4oJts7miiLkR3WTfsqxUtxwJzvt6xy1zGD)