### PR TITLE
[TRA-17156] ETQ utilisateur je veux voir la bonne entreprise après une recherche sur le n°SIRET

### DIFF
--- a/front/src/Apps/Companies/CompanyDetails.tsx
+++ b/front/src/Apps/Companies/CompanyDetails.tsx
@@ -129,7 +129,14 @@ export default function CompanyDetails() {
   }
 
   const companies = data?.myCompanies?.edges.map(({ node }) => node);
-  const company = companies && companies[0];
+  let company = companies && companies[0];
+
+  // TRA-17156: l'utilisateur peut avoir mis le siret d'une entreprise dans le
+  // nom usuel d'une autre. Si c'est le cas, on retourne en priorité l'entreprise
+  // dont le siret (pas le nom usuel) correspond au siret dans l'URL.
+  if (companies && companies?.length > 1) {
+    company = companies.find(c => c.siret === siret) ?? companies[0];
+  }
 
   if (!company) {
     return <Navigate to={{ pathname: routes.companies.index }} />;


### PR DESCRIPTION
# Contexte

Description du bug:
- Créer 2 entreprises A et B
- Dans le nom usuel de l'entreprise A, ajouter le siret de l'entreprise B (ex: "Freddy Mécanique (utiliser ça, pas SIRETB)"
- Dans l'onglet entreprises, cliquer sur l'entreprise B
- C'est l'entreprise A qui s'affiche.

Pourquoi?

Parce que la vue CompanyDetails utilise MyCompanies, qui utilise le siret comme un paramètre de recherche (tous champs confondus). Vu que l'entreprise A est le premier résultat à remonter contenant le siret de l'entreprise B, c'est elle qui est affichée.

Pour faire simple & rapide, j'ai corrigé ça côté front, mais il faudrait probablement faire une query spéciale pour cette vue, c'est un peu ridicule d'utiliser cette query graphQL.

# Démo du bug

https://github.com/user-attachments/assets/9f73d2cb-ea01-4d09-8d29-93da6f75a33a

# Ticket Favro

[Impossible d’accéder à un établissement si son SIRET est renseigné dans le nom usuel d’un autre](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-17156)
