### PR TITLE
Hotfix/Taille du code ONU & correctif certif amiante

### DIFF
--- a/back/src/bsda/validation/transformers.ts
+++ b/back/src/bsda/validation/transformers.ts
@@ -78,7 +78,10 @@ export async function fillWorkerCertification(
     bsda.workerCertificationCertificationNumber =
       certification.certificationNumber;
     bsda.workerCertificationValidityLimit = certification.validityLimit;
-    bsda.workerCertificationOrganisation = certification.organisation as any;
+    bsda.workerCertificationOrganisation =
+      certification.organisation !== ""
+        ? (certification.organisation as any)
+        : null;
   }
 
   return bsda;

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -918,7 +918,7 @@ const baseWasteDetailsSchemaFn: FactorySchemaOf<
     wasteDetailsIsSubjectToADR: yup.boolean().nullable(),
     wasteDetailsOnuCode: yup
       .string()
-      .max(250)
+      .max(750)
       .nullable()
       // Empty values (or spaces) to null
       .transform(value =>


### PR DESCRIPTION
- Il faut agrandir la limite de caractères pour les certifs amiante
- si la certif amiante est une string vide il ne faut pas auto compléter la valeur