### PR TITLE
[TRA-17185] Ajout d'une taille limite plus stricte aux PDFs d'entreprises anonymes

### DIFF
--- a/back/src/companies/resolvers/mutations/createAnonymousCompanyFromPDF.ts
+++ b/back/src/companies/resolvers/mutations/createAnonymousCompanyFromPDF.ts
@@ -30,8 +30,6 @@ const createAnonymousCompanyFromPDFResolver: MutationResolvers["createAnonymousC
 
     const { siret, pdf } = input;
 
-    console.log("pdf", pdf.length);
-
     // Run verifications & extract data from PDF
     const data = await validateAndExtractSireneDataFromPDFInBase64(pdf);
 

--- a/back/src/companies/resolvers/mutations/createAnonymousCompanyFromPDF.ts
+++ b/back/src/companies/resolvers/mutations/createAnonymousCompanyFromPDF.ts
@@ -12,10 +12,12 @@ import { base64, siret } from "../../../common/validation";
 import { UserInputError } from "../../../common/errors";
 import { libelleFromCodeNaf } from "../../sirene/utils";
 
+const ONE_MB = 1024 * 1024;
+
 const anonymousCompanyInputSchema: yup.SchemaOf<CreateAnonymousCompanyFromPdfInput> =
   yup.object({
     siret: siret.required(),
-    pdf: base64.required()
+    pdf: base64.max(3 * ONE_MB).required()
   });
 
 const createAnonymousCompanyFromPDFResolver: MutationResolvers["createAnonymousCompanyFromPDF"] =
@@ -27,6 +29,8 @@ const createAnonymousCompanyFromPDFResolver: MutationResolvers["createAnonymousC
     await anonymousCompanyInputSchema.validate(input);
 
     const { siret, pdf } = input;
+
+    console.log("pdf", pdf.length);
 
     // Run verifications & extract data from PDF
     const data = await validateAndExtractSireneDataFromPDFInBase64(pdf);


### PR DESCRIPTION
# Contexte

Il n'y a pas de limite spéciale pour l'endpoint createAnonymousCompanyFromPDF, donc on peut uploader un truc assez gros (25Mo), ce qui peut faire ramer les machines

# Ticket Favro

[Ajout d'une taille limite plus stricte aux PDFs d'entreprises anonymes](https://favro.com/widget/ab14a4f0460a99a9d64d4945/2469e9802a85b5812977661f?card=tra-17185)
