### PR TITLE
[TRA 17114] Passer les noms du dashboard en capitalize

### DIFF
--- a/front/src/Apps/Dashboard/Components/Actors/Actors.tsx
+++ b/front/src/Apps/Dashboard/Components/Actors/Actors.tsx
@@ -15,7 +15,7 @@ function Actors({
   destinationName,
   workerCompanyName
 }: ActorsProps) {
-  const split = label => {
+  const split = (label: string) => {
     const maxVisible = 20;
     const maxSubstract = 9;
     return label.length > maxVisible

--- a/front/src/Apps/Dashboard/Components/Actors/actors.scss
+++ b/front/src/Apps/Dashboard/Components/Actors/actors.scss
@@ -28,13 +28,12 @@
 
     &--second {
       flex-shrink: 0;
+
+      text-transform: lowercase;
     }
   }
-  &__label:first-letter {
-    text-transform: capitalize;
-  }
 
-  &__label:first-letter {
+  &__label--first::first-letter {
     text-transform: capitalize;
   }
 

--- a/front/src/Apps/Dashboard/Components/InfoWithIcon/InfoWithIcon.tsx
+++ b/front/src/Apps/Dashboard/Components/InfoWithIcon/InfoWithIcon.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from "react";
 import { InfoIconCode, InfoWithIconProps } from "./infoWithIconTypes";
 import { getLabelValue } from "./infoWithIconUtils";
 import "./infoWithIcon.scss";
+import Tooltip from "../../../common/Components/Tooltip/Tooltip";
 
 function InfoWithIcon({
   labelCode,
@@ -40,11 +41,22 @@ function InfoWithIcon({
   };
 
   const customInfo = editableInfos?.customInfo || "-";
+  const title: string = !hasEditableInfos
+    ? !info
+      ? labelValue
+      : `${labelValue} ${info}`
+    : labelCode === InfoIconCode.CustomInfo
+    ? (customInfo as string)
+    : formatTranporterPlates(editableInfos?.transporterNumberPlate);
+
   return !hasEditableInfos ? (
-    <p className={`label-icon label-icon__${labelCode}`}>
-      <span className="fr-sr-only">{displayAlternativeText()}</span>
-      {!info ? labelValue : `${labelValue} ${info}`}
-    </p>
+    <Tooltip title={title}>
+      <p className={`label-icon label-icon__${labelCode}`}>
+        <span className="fr-sr-only">{displayAlternativeText()}</span>
+
+        <span className={`label-icon__text`}>{title}</span>
+      </p>
+    </Tooltip>
   ) : (
     <button
       className="label-icon-editable"
@@ -53,14 +65,14 @@ function InfoWithIcon({
       disabled={isDisabled}
       title={labelValue}
     >
-      <p className={`label-icon label-icon__${labelCode}`}>
-        <span className="fr-sr-only">
-          Modifier le champ libre et l'immatriculation
-        </span>
-        {labelCode === InfoIconCode.CustomInfo
-          ? customInfo
-          : formatTranporterPlates(editableInfos?.transporterNumberPlate)}
-      </p>
+      <Tooltip title={title}>
+        <p className={`label-icon label-icon__${labelCode}`}>
+          <span className="fr-sr-only">
+            Modifier le champ libre et l'immatriculation
+          </span>
+          <span className={`label-icon__text`}>{title}</span>
+        </p>
+      </Tooltip>
       {labelCode === InfoIconCode.TransporterNumberPlate && !isDisabled && (
         <>
           <span className="fr-sr-only">

--- a/front/src/Apps/Dashboard/Components/InfoWithIcon/infoWithIcon.scss
+++ b/front/src/Apps/Dashboard/Components/InfoWithIcon/infoWithIcon.scss
@@ -27,6 +27,14 @@
   display: flex;
   align-items: center;
 
+  &__text {
+    display: inline-block;
+    max-width: 200px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
   &__TempStorage {
     &:before {
       display: inline-block;
@@ -67,6 +75,7 @@
       width: 24px;
       height: 25px;
       vertical-align: middle;
+      flex-shrink: 0;
     }
     max-width: 200px;
     text-overflow: ellipsis;

--- a/front/src/Apps/Dashboard/Components/InfoWithIcon/infoWithIcon.scss
+++ b/front/src/Apps/Dashboard/Components/InfoWithIcon/infoWithIcon.scss
@@ -33,6 +33,12 @@
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+
+    text-transform: lowercase;
+
+    &::first-letter {
+      text-transform: capitalize;
+    }
   }
 
   &__TempStorage {
@@ -96,12 +102,15 @@
     }
   }
   &__TransporterNumberPlate {
+    .label-icon__text {
+      text-transform: uppercase;
+    }
     &:before {
       background-image: url("/icons/dashboard/transporter-number-plate-icon.svg");
     }
   }
+
   &__PickupSite {
-    text-transform: lowercase;
     &:before {
       display: inline-block;
       content: "";

--- a/front/src/Apps/Dashboard/Components/Revision/ActorStatus/ActorSatus.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/ActorStatus/ActorSatus.tsx
@@ -1,6 +1,7 @@
 import {
   BsdaRevisionRequestApproval,
   FormRevisionRequestApproval,
+  BsdasriRevisionRequestApproval,
   RevisionRequestApprovalStatus
 } from "@td/codegen-ui";
 import React from "react";
@@ -59,9 +60,19 @@ const ActorStatus = ({ review }: { review: ReviewInterface }) => {
           )}
 
           <p className="actor-name">
-            {approvals.map(approval => (
-              <p>{getActorName(review?.bsdContent, approval?.approverSiret)}</p>
-            ))}
+            {approvals.map(
+              (
+                approval:
+                  | BsdaRevisionRequestApproval
+                  | BsdasriRevisionRequestApproval
+                  | FormRevisionRequestApproval,
+                index: number
+              ) => (
+                <p key={index}>
+                  {getActorName(review?.bsdContent, approval?.approverSiret)}
+                </p>
+              )
+            )}
           </p>
         </div>
       ))}


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Appliquer la règle de la première lettre en majuscules uniquement sur toutes les raisons sociales affichées dans l'UI

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

<img width="1260" height="988" alt="image" src="https://github.com/user-attachments/assets/596ab687-4673-4c9d-b440-fb86d26caa04" />


# Ticket Favro

[Appliquer la règle de la première lettre en majuscules uniquement sur toutes les raisons sociales affichées dans l'UI](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-17114)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB