### PR TITLE
TRA-17112 Prevent auth code reuse on oauth workflow

### DIFF
--- a/back/src/oauth/oauth2.ts
+++ b/back/src/oauth/oauth2.ts
@@ -96,7 +96,13 @@ oauth2server.exchange(
       );
       return done(err);
     }
-
+    if (grant.used) {
+      const err = new TokenError(
+        tokenErrorMessages.grant_expired,
+        "invalid_grant"
+      );
+      return done(err);
+    }
     const clearToken = getUid(40);
 
     await prisma.accessToken.create({
@@ -109,6 +115,11 @@ oauth2server.exchange(
         },
         token: hashToken(clearToken)
       }
+    });
+
+    await prisma.grant.update({
+      where: { id: grant.id },
+      data: { used: true }
     });
 
     // Add custom params

--- a/libs/back/prisma/src/migrations/20250930073627_oauth_grante_use/migration.sql
+++ b/libs/back/prisma/src/migrations/20250930073627_oauth_grante_use/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "default$default"."Grant" ADD COLUMN     "used" BOOLEAN NOT NULL DEFAULT false;

--- a/libs/back/prisma/src/models/main.prisma
+++ b/libs/back/prisma/src/models/main.prisma
@@ -748,6 +748,7 @@ model Grant {
   updatedAt     DateTime    @updatedAt @db.Timestamptz(6)
   code          String      @unique(map: "Grant.code._UNIQUE")
   expires       Int
+  used          Boolean     @default(false) // Flag to prevent auth code reuse on oauth workflow
   redirectUri   String
   scope         String[]    @default([])
   nonce         String?


### PR DESCRIPTION
# Contexte

Correction du ticket bug bounty: le token pouavait être demandé plusieurs fois pendant la validité du grant (10mn)

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

 https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-17112

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB