### PR TITLE
[TRA 17217] Verrouillage du mécanisme de 2fa (throttling)

### DIFF
--- a/back/src/auth/totpStrategy.ts
+++ b/back/src/auth/totpStrategy.ts
@@ -4,6 +4,33 @@ import { TOTP } from "totp-generator";
 import { prisma } from "@td/prisma";
 import { sanitizeEmail } from "../utils";
 import { User } from "@prisma/client";
+import { addSeconds } from "date-fns";
+
+const TOTP_LOCK_FACTOR = 5;
+
+const increaseLock = async (user?: User) => {
+  if (!user) {
+    return null;
+  }
+  if (user.totpLockedUntil && user.totpLockedUntil > new Date()) {
+    // ignore if user tries before lock expiration
+    return null;
+  }
+  const totpFails = user.totpFails + 1;
+  const totpLockedUntil = addSeconds(new Date(), totpFails * TOTP_LOCK_FACTOR);
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { totpFails, totpLockedUntil }
+  });
+  return totpLockedUntil;
+};
+
+const resetLock = async (user: User) => {
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { totpFails: 0, totpLockedUntil: null }
+  });
+};
 
 /**
  * Custom Authentication Strategy for Passport.js
@@ -17,11 +44,18 @@ export class TotpStrategy extends PassportStrategy {
    * This is the core method that Passport will call
    * when using this strategy
    *
+   *  Lockout logic:
+   *  - each time a wrong totp is submitted,
+   *      - the `totpFails` count is increased
+   *      - the `totpLockedUntil` is set to `totpFails` * 5 s  in the future
+   *      - the lockout params is returned alongside the error code, allowing the UI to handle the response querytsring and inform the user
+   *  - during lockout period, totp submission are ignored
+   *  - once lockout expired, successful totp submission resets `totpFails` and `totpLockedUntil`
+   *
    * @param req - The request object
    */
   async authenticate(req: Request): Promise<void> {
     // Extract credentials from request
-    // This is where your custom authentication logic goes
     const { totp } = req.body;
     const userEmail = req.session?.preloggedUser?.userEmail;
     const expire = req.session?.preloggedUser?.expire;
@@ -29,11 +63,14 @@ export class TotpStrategy extends PassportStrategy {
     if (!expire || !userEmail) {
       return this.fail({ code: "TOTP_TIMEOUT_OR_MISSING_SESSION" }, 401);
     }
+    const user = await prisma.user.findUnique({
+      where: { email: sanitizeEmail(userEmail) }
+    });
 
     if (new Date(expire) < new Date()) {
       // prelogging expired, user will be redirected to login
       delete req.session.preloggedUser;
-
+      await resetLock(user!);
       return this.fail({ code: "TOTP_TIMEOUT_OR_MISSING_SESSION" }, 401);
     }
 
@@ -41,16 +78,21 @@ export class TotpStrategy extends PassportStrategy {
       return this.fail({ code: "MISSING_TOTP" }, 401);
     }
 
-    const user = await prisma.user.findUnique({
-      where: { email: sanitizeEmail(userEmail) }
-    });
-    // Call verify function to validate the totp
+    if (user?.totpLockedUntil && user.totpLockedUntil > new Date()) {
+      const lockout = user.totpLockedUntil.getTime();
+      return this.fail({ code: `TOTP_LOCKOUT`, lockout }, 401);
+    }
 
+    // Call verify function to validate the totp
     try {
       const verifiedUser = await this.verifyTotp(totp, user);
       if (!verifiedUser) {
-        return this.fail({ code: "INVALID_TOTP" }, 401);
+        // increase lockout time (fail * TOTP_LOCK_FACTOR seconds)
+        const totpLockedUntil = await increaseLock(user!);
+        const lockout = totpLockedUntil?.getTime();
+        return this.fail({ code: "INVALID_TOTP", lockout }, 401);
       }
+      await resetLock(user!);
       this.success(verifiedUser);
     } catch (err) {
       this.error(err);

--- a/back/src/bsvhu/resolvers/mutations/sign.ts
+++ b/back/src/bsvhu/resolvers/mutations/sign.ts
@@ -42,7 +42,6 @@ export default async function sign(
   });
 
   const signatureType = getBsvhuSignatureType(input.type, bsvhu);
-  console.log(`Signature type: ${signatureType}`);
   const authorizedOrgIds = getAuthorizedOrgIds(bsvhu, signatureType);
 
   // To sign a form for a company, you must either:

--- a/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
+++ b/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
@@ -176,7 +176,6 @@ describe("Query.Bsvhu", () => {
       variables: { id: bsd.id }
     });
 
-    console.log(data.bsvhu.metadata?.fields?.sealed);
     expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(98);
   });
 });

--- a/back/src/routers/auth-router.ts
+++ b/back/src/routers/auth-router.ts
@@ -69,12 +69,14 @@ authRouter.post("/otp", (req, res, next) => {
     if (!user) {
       const queries = {
         ...{
-          errorCode: info.code
+          errorCode: info.code,
+          ...(info?.lockout ? { lockout: info.lockout } : {})
         },
         ...(req.body.returnTo
           ? { returnTo: getSafeReturnTo(req.body.returnTo, UI_BASE_URL) }
           : {})
       };
+
       if (info.code === "TOTP_TIMEOUT_OR_MISSING_SESSION") {
         return res.redirect(
           `${UI_BASE_URL}/login?${querystring.stringify(queries)}`

--- a/libs/back/prisma/src/migrations/migrations/20250930150526_user_totp_fails_totp_locked_until/migration.sql
+++ b/libs/back/prisma/src/migrations/migrations/20250930150526_user_totp_fails_totp_locked_until/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "default$default"."User" ADD COLUMN     "totpFails" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "totpLockedUntil" TIMESTAMP(3);

--- a/libs/back/prisma/src/models/main.prisma
+++ b/libs/back/prisma/src/models/main.prisma
@@ -918,6 +918,8 @@ model User {
   governmentAccount    GovernmentAccount? @relation(fields: [governmentAccountId], references: [id])
   totpSeed             String?
   totpActivatedAt      DateTime?          @db.Timestamptz(6)
+  totpFails            Int                @default(0)
+  totpLockedUntil      DateTime?
   trackingConsent      Boolean            @default(false)
   trackingConsentUntil DateTime?
 


### PR DESCRIPTION
# Contexte

Correction ticket bug bounty.
Le 2nd factor totp peut être brute forcé (2 / 10e6 combinaisons en 30 secondes) .
Cette PR implémente un mécanisme de verrouillage progressif pour limiter les tentatives de soumission de codes TOTP invalides.

### Fonctionnement :
2 champs sont ajoutés au modèle User totpLockedUntil(Date) et totpFails(Int).

En cas d'échec : À chaque soumission d'un code TOTP incorrect :

- Le compteur totpFails est incrémenté
- Le timestamp totpLockedUntil est défini à totpFails × 5 secondes dans le futur
- Les paramètres de verrouillage sont retournés avec le code d'erreur, permettant à l'interface utilisateur de traiter la réponse et d'informer l'utilisateur


Pendant le verrouillage : Toutes les tentatives de soumission de code TOTP sont ignorées

Après expiration du verrouillage : Une soumission réussie réinitialise totpFails et totpLockedUntil à zéro

Ce système empêche les attaques par force brute tout en appliquant une pénalité progressive qui augmente avec le nombre de tentatives échouées.

Côté front, un compte à rebours décompte le délai de blocage.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo
 

https://github.com/user-attachments/assets/4691385d-a841-4509-8d37-bf851a7a73cb



# Ticket Favro

 https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-17217

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB