### PR TITLE
feat(bsff): #TRA-14602 Permettre à la destination de modifier ses inf…

### DIFF
--- a/front/src/form/bsff/Destination.tsx
+++ b/front/src/form/bsff/Destination.tsx
@@ -4,10 +4,10 @@ import CompanySelector from "../common/components/company/CompanySelector";
 import { OPERATION } from "./utils/constants";
 import { RedErrorMessage } from "../../common/components";
 
-export default function Destination({ disabled }) {
+export default function Destination({ disabled, contactFieldsDisabled }) {
   return (
     <>
-      {disabled && (
+      {(disabled || contactFieldsDisabled) && (
         <div className="notification notification--error">
           Les champs ci-dessous ont été scellés via signature et ne sont plus
           modifiables.
@@ -16,6 +16,7 @@ export default function Destination({ disabled }) {
 
       <CompanySelector
         disabled={disabled}
+        contactFieldsDisabled={contactFieldsDisabled}
         registeredOnlyCompanies={true}
         name="destination.company"
         heading="Installation de destination"

--- a/front/src/form/bsff/FormContainer.tsx
+++ b/front/src/form/bsff/FormContainer.tsx
@@ -24,7 +24,8 @@ export default function FormContainer() {
             // emitter can still update any field after his own signature
             const disabledAfterEmission =
               (emitterSigned && !isEmitter) || transporterSigned;
-
+            const operationSigned =
+              bsff?.destination?.reception?.signature?.author != null;
             return (
               <>
                 <StepContainer
@@ -49,7 +50,7 @@ export default function FormContainer() {
                 <StepContainer
                   component={Recipient}
                   title="Destination du déchet"
-                  disabled={disabledAfterEmission}
+                  disabled={operationSigned}
                 />
               </>
             );

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -63,6 +63,7 @@ interface CompanySelectorProps {
   registeredOnlyCompanies?: boolean;
   heading?: string;
   disabled?: boolean;
+  contactFieldsDisabled?: boolean;
   optionalMail?: boolean;
   skipFavorite?: boolean;
   isBsdaTransporter?: boolean;
@@ -79,6 +80,7 @@ export default function CompanySelector({
   registeredOnlyCompanies = false,
   heading,
   disabled,
+  contactFieldsDisabled,
   optionalMail = false,
   skipFavorite = false,
   isBsdaTransporter = false,
@@ -585,7 +587,7 @@ export default function CompanySelector({
               name={`${field.name}.contact`}
               placeholder="NOM Prénom"
               className="td-input"
-              disabled={disabled}
+              disabled={contactFieldsDisabled}
             />
           </label>
           <RedErrorMessage name={`${field.name}.contact`} />
@@ -598,7 +600,7 @@ export default function CompanySelector({
               name={`${field.name}.phone`}
               placeholder="Numéro"
               className={`td-input ${styles.companySelectorSearchPhone}`}
-              disabled={disabled}
+              disabled={contactFieldsDisabled}
             />
           </label>
 
@@ -611,7 +613,7 @@ export default function CompanySelector({
               type="email"
               name={`${field.name}.mail`}
               className={`td-input ${styles.companySelectorSearchEmail}`}
-              disabled={disabled}
+              disabled={contactFieldsDisabled}
             />
           </label>
 

--- a/front/src/form/common/stepper/Step.tsx
+++ b/front/src/form/common/stepper/Step.tsx
@@ -7,6 +7,7 @@ export interface IStepContainerProps {
   children?: JSX.Element;
   title: string;
   disabled?: boolean;
+  contactFieldsDisabled?: boolean;
   status?: string;
   stepName?: string;
   form?: Form | undefined;
@@ -15,6 +16,7 @@ export function StepContainer(props: IStepContainerProps) {
   return props.component
     ? createElement(props.component, {
         disabled: props.disabled,
+        contactFieldsDisabled: props.contactFieldsDisabled,
         status: props.status,
         stepName: props.stepName,
         form: props.form


### PR DESCRIPTION
…ormations de contact jusqu'à sa signature (ne pas les sceller à la signature émetteur)

# Contexte

En tant que, acteur visé sur un BSFF initial, de regroupement, de reconditionnement et de réexpédition,
Je souhaite, être en mesure de modifier les informations de contact de la destination jusqu'à ce que le BSFF soit au statut réceptionné, 
Afin de, pouvoir corriger toute erreur avant la signature de la destination. 

# Points de vigilance pour les intégrateurs
<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo
<img width="1601" height="851" alt="image" src="https://github.com/user-attachments/assets/17a1b0cf-fec8-411e-92f3-6fe1440a57e4" />

# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14602
# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB