### PR TITLE
[TRA 17379] Ajout du siret de la destination ultérieure BSVHU aux exports registre et pays sur PDF

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Par défaut, afficher le composant du transporteur ouvert sur les formulaires de déclarations au registre national [PR 4677](https://github.com/MTES-MCT/trackdechets/pull/4677)
 - Ajout des codes groupement (D13 et R12) à la révision BSDASRI [PR 4688](https://github.com/MTES-MCT/trackdechets/pull/4688)
+- Ajout du siret de la destination ultérieure BSVHU aux exports registre et pays sur PDF [PR 4706](https://github.com/MTES-MCT/trackdechets/pull/4706)
 
 #### :bug: Corrections de bugs
 

--- a/back/src/bsvhu/pdf/components/BsvhuPdf.tsx
+++ b/back/src/bsvhu/pdf/components/BsvhuPdf.tsx
@@ -565,7 +565,7 @@ export function BsvhuPdf({ bsvhu, qrCode, renderEmpty }: Props) {
             <div className="BoxCol">
               <strong>12. Installation de broyage prévisionnelle </strong>
               <p>
-                SIRET:{" "}
+                Numéro d'identification:{" "}
                 {bsvhu?.destination?.operation?.nextDestination?.company?.siret}
               </p>
               <p>
@@ -577,6 +577,18 @@ export function BsvhuPdf({ bsvhu, qrCode, renderEmpty }: Props) {
                 Adresse:{" "}
                 {bsvhu?.destination?.operation?.nextDestination?.company
                   ?.address ?? ""}
+                {bsvhu?.destination?.operation?.nextDestination?.company
+                  ?.country
+                  ? `${
+                      bsvhu?.destination?.operation?.nextDestination?.company
+                        ?.address
+                        ? " ,"
+                        : ""
+                    }${
+                      bsvhu?.destination?.operation?.nextDestination?.company
+                        ?.country
+                    }`
+                  : ""}
               </p>
               <p>
                 Tel:{" "}

--- a/back/src/bsvhu/registryV2.ts
+++ b/back/src/bsvhu/registryV2.ts
@@ -329,6 +329,18 @@ export const toOutgoingWasteV2 = (
     city: destinationCompanyCity,
     country: destinationCompanyCountry
   } = splitAddress(bsvhu.destinationCompanyAddress);
+
+  const destinationFinalOperationCompanySiret =
+    bsvhu.destinationOperationNextDestinationCompanySiret ??
+    bsvhu.destinationOperationNextDestinationCompanyVatNumber ??
+    bsvhu.destinationOperationNextDestinationCompanyExtraEuropeanId ??
+    null;
+
+  const destinationFinalOperationCompanySirets =
+    destinationFinalOperationCompanySiret
+      ? [destinationFinalOperationCompanySiret]
+      : null;
+
   return {
     ...emptyOutgoingWasteV2,
     id: bsvhu.id,
@@ -453,7 +465,7 @@ export const toOutgoingWasteV2 = (
     nextDestinationPlannedOperationCodes: null,
     destinationHasCiterneBeenWashedOut: null,
     destinationOperationNoTraceability: false,
-    destinationFinalOperationCompanySirets: null,
+    destinationFinalOperationCompanySirets,
     destinationFinalOperationCodes: null,
     destinationFinalOperationWeights: null,
     gistridNumber: null,
@@ -858,6 +870,18 @@ export const toManagedWasteV2 = (
     city: destinationCompanyCity,
     country: destinationCompanyCountry
   } = splitAddress(bsvhu.destinationCompanyAddress);
+
+  const destinationFinalOperationCompanySiret =
+    bsvhu.destinationOperationNextDestinationCompanySiret ??
+    bsvhu.destinationOperationNextDestinationCompanyVatNumber ??
+    bsvhu.destinationOperationNextDestinationCompanyExtraEuropeanId ??
+    null;
+
+  const destinationFinalOperationCompanySirets =
+    destinationFinalOperationCompanySiret
+      ? [destinationFinalOperationCompanySiret]
+      : null;
+
   return {
     ...emptyManagedWasteV2,
     id: bsvhu.id,
@@ -1033,7 +1057,7 @@ export const toManagedWasteV2 = (
     nextDestinationPlannedOperationCodes: null,
     destinationHasCiterneBeenWashedOut: null,
     destinationOperationNoTraceability: false,
-    destinationFinalOperationCompanySirets: null,
+    destinationFinalOperationCompanySirets,
     destinationFinalOperationCodes: null,
     destinationFinalOperationWeights: null,
     gistridNumber: null,
@@ -1124,6 +1148,18 @@ export const toAllWasteV2 = (
     city: destinationCompanyCity,
     country: destinationCompanyCountry
   } = splitAddress(bsvhu.destinationCompanyAddress);
+
+  const destinationFinalOperationCompanySiret =
+    bsvhu.destinationOperationNextDestinationCompanySiret ??
+    bsvhu.destinationOperationNextDestinationCompanyVatNumber ??
+    bsvhu.destinationOperationNextDestinationCompanyExtraEuropeanId ??
+    null;
+
+  const destinationFinalOperationCompanySirets =
+    destinationFinalOperationCompanySiret
+      ? [destinationFinalOperationCompanySiret]
+      : null;
+
   return {
     ...emptyAllWasteV2,
     id: bsvhu.id,
@@ -1303,7 +1339,7 @@ export const toAllWasteV2 = (
     nextDestinationPlannedOperationCodes: null,
     destinationHasCiterneBeenWashedOut: null,
     destinationOperationNoTraceability: false,
-    destinationFinalOperationCompanySirets: null,
+    destinationFinalOperationCompanySirets,
     destinationFinalOperationCodes: null,
     destinationFinalOperationWeights: null,
     gistridNumber: null,


### PR DESCRIPTION
# Contexte

Le SIRET de la destination ultérieure doit remonter sur les exports dans destinationFinalOperationCompanySirets. Les infos de pays doivent aussi remonter dans l'adresse sur le PDF.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Remonter la destination ultérieure visée sur les registres, colonne Destination finale - N° d'identification ainsi que sur le PDF](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-17379)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB