### PR TITLE
[TRA 17928] nettoyer infos certif section 3 BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Creation/bsda/steps/Worker.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsda/steps/Worker.tsx
@@ -73,6 +73,10 @@ const Worker = () => {
               "worker.certification.organisation",
               workerSelected?.workerCertification?.organisation
             );
+          } else {
+            setValue("worker.certification.certificationNumber", null);
+            setValue("worker.certification.validityLimit", null);
+            setValue("worker.certification.organisation", null);
           }
         } else {
           setValue("worker.certification", null);


### PR DESCRIPTION
# Contexte

Si le BSDA avait été rempli avec un établissement ayant une certification section 3, puis l'établissement remplacé par un autre ayant une section 4, des infos de la section 3 restaient dans le bordereau et faisaient échouer la validation. Je cleanup les infos pour éviter le soucis.

# Points de vigilance pour les intégrateurs

X

# Démo

X

# Ticket Favro

[Impossible d’enregistrer les modifications réalisés sur un BSDA sans message d’erreur](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-17928)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB