### PR TITLE
fix(BSDASRI): Afficher la mention "quantité estimée conformément au 5.4.1.1.3.2" uniquement si la case "Ce poids est estimé" a été coché sur le BSDASRI

### DIFF
--- a/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
+++ b/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
@@ -205,16 +205,21 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               checked={bsdasri?.emitter?.emission?.weight?.isEstimate === false}
               readOnly
             />{" "}
-            réelle
+            Réelle
             <br />
             <input
               type="checkbox"
               checked={bsdasri?.emitter?.emission?.weight?.isEstimate === true}
               readOnly
             />{" "}
-            Estimée
-            <br />
-            "QUANTITÉ ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
+            <span style={{ whiteSpace: "nowrap" }}>
+              Estimée{" "}
+              {bsdasri?.emitter?.emission?.weight?.isEstimate ? (
+                <>("Quantité estimée conformément au 5.4.1.1.3.2" de l'ADR)</>
+              ) : (
+                ""
+              )}
+            </span>
           </div>
         </div>
         {/* End PRED */}
@@ -341,7 +346,7 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               }
               readOnly
             />{" "}
-            réelle <span> - </span>
+            Réelle <span> - </span>
             <input
               type="checkbox"
               checked={
@@ -349,9 +354,14 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               }
               readOnly
             />{" "}
-            Estimée
-            <br />
-            "QUANTITÉ ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
+            <span style={{ whiteSpace: "nowrap" }}>
+              Estimée{" "}
+              {bsdasri?.transporter?.transport?.weight?.isEstimate ? (
+                <>("Quantité estimée conformément au 5.4.1.1.3.2" de l'ADR)</>
+              ) : (
+                ""
+              )}
+            </span>
           </div>
         </div>
         {/* End Transporter */}


### PR DESCRIPTION
# Contexte

Correction du rendu PDF BSDASRI pour afficher la mention liée à la quantité estimée uniquement lorsque la case Estimée est cochée.

# Démo
<img width="513" height="427" alt="image" src="https://github.com/user-attachments/assets/988ecece-468d-4456-8114-cfd070684881" />

<img width="534" height="427" alt="image" src="https://github.com/user-attachments/assets/bbade353-a69d-4495-b00e-6c97779544cd" />

# Ticket Favro

[Afficher la mention "quantité estimée conformément au 5.4.1.1.3.2" uniquement si la case "Ce poids est estimé" a été coché sur le BSDASRI](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-17890)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB