### PR TITLE
[TRA-17181] La modal de signature transporteur (BSDD) permet désormais au transporteur de modifier son contact, email, numéro de téléphone

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/signTransportForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/signTransportForm.integration.ts
@@ -23,6 +23,13 @@ const SIGN_TRANSPORT_FORM = `
       sentBy
       takenOverAt
       takenOverBy
+      transporter {
+        company {
+          contact
+          mail
+          phone
+        }
+      }
       temporaryStorageDetail {
         signedAt
         signedBy
@@ -1775,6 +1782,247 @@ describe("signTransportForm", () => {
       // Then
       expect(errors).not.toBeUndefined();
       expect(errors[0].message).toBe("Le mode de transport est obligatoire");
+    });
+  });
+
+  describe("[TRA-17181] Transporter can update contact, email, phone at signature step", () => {
+    it("should update contact, email, phone", async () => {
+      // Given
+      const emitter = await userWithCompanyFactory("ADMIN");
+      const transporter = await userWithCompanyFactory("ADMIN");
+      await transporterReceiptFactory({ company: transporter.company });
+      const emittedAt = new Date("2018-12-11T00:00:00.000Z");
+      const takenOverAt = new Date("2018-12-12T00:00:00.000Z");
+      const form = await formFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          status: "SIGNED_BY_PRODUCER",
+          emitterCompanySiret: emitter.company.siret,
+          emitterCompanyName: emitter.company.name,
+          signedByTransporter: null,
+          sentAt: null,
+          sentBy: null,
+          emittedAt: emittedAt,
+          emittedBy: emitter.user.name,
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              transporterCompanyName: transporter.company.name,
+              transporterCompanyContact: "Old contact",
+              transporterCompanyMail: "old.email@mail.com",
+              transporterCompanyPhone: "0102030405",
+              number: 1
+            }
+          }
+        }
+      });
+
+      // When
+      const { mutate } = makeClient(transporter.user);
+      const { errors, data } = await mutate<
+        Pick<Mutation, "signTransportForm">,
+        MutationSignTransportFormArgs
+      >(SIGN_TRANSPORT_FORM, {
+        variables: {
+          id: form.id,
+          input: {
+            takenOverAt: takenOverAt.toISOString() as unknown as Date,
+            takenOverBy: transporter.user.name,
+            transporterCompanyContact: "New contact",
+            transporterCompanyMail: "new.email@mail.com",
+            transporterCompanyPhone: "0605040302"
+          }
+        }
+      });
+
+      // Then
+      expect(errors).toBeUndefined();
+      expect(data.signTransportForm).toEqual(
+        expect.objectContaining({
+          status: "SENT",
+
+          signedByTransporter: true,
+          sentAt: takenOverAt.toISOString(),
+          sentBy: emitter.user.name,
+
+          takenOverAt: takenOverAt.toISOString(),
+          takenOverBy: transporter.user.name,
+          transporter: {
+            company: {
+              contact: "New contact",
+              mail: "new.email@mail.com",
+              phone: "0605040302"
+            }
+          }
+        })
+      );
+    });
+
+    it("user does not have to re-feed contact, email, phone", async () => {
+      // Given
+      const emitter = await userWithCompanyFactory("ADMIN");
+      const transporter = await userWithCompanyFactory("ADMIN");
+      await transporterReceiptFactory({ company: transporter.company });
+      const emittedAt = new Date("2018-12-11T00:00:00.000Z");
+      const takenOverAt = new Date("2018-12-12T00:00:00.000Z");
+      const form = await formFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          status: "SIGNED_BY_PRODUCER",
+          emitterCompanySiret: emitter.company.siret,
+          emitterCompanyName: emitter.company.name,
+          signedByTransporter: null,
+          sentAt: null,
+          sentBy: null,
+          emittedAt: emittedAt,
+          emittedBy: emitter.user.name,
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              transporterCompanyName: transporter.company.name,
+              transporterCompanyContact: "Old contact",
+              transporterCompanyMail: "old.email@mail.com",
+              transporterCompanyPhone: "0102030405",
+              number: 1
+            }
+          }
+        }
+      });
+
+      // When
+      const { mutate } = makeClient(transporter.user);
+      const { errors, data } = await mutate<
+        Pick<Mutation, "signTransportForm">,
+        MutationSignTransportFormArgs
+      >(SIGN_TRANSPORT_FORM, {
+        variables: {
+          id: form.id,
+          input: {
+            takenOverAt: takenOverAt.toISOString() as unknown as Date,
+            takenOverBy: transporter.user.name
+          }
+        }
+      });
+
+      // Then
+      expect(errors).toBeUndefined();
+      expect(data.signTransportForm).toEqual(
+        expect.objectContaining({
+          status: "SENT",
+
+          signedByTransporter: true,
+          sentAt: takenOverAt.toISOString(),
+          sentBy: emitter.user.name,
+
+          takenOverAt: takenOverAt.toISOString(),
+          takenOverBy: transporter.user.name,
+          transporter: {
+            company: {
+              contact: "Old contact",
+              mail: "old.email@mail.com",
+              phone: "0102030405"
+            }
+          }
+        })
+      );
+    });
+
+    it("should update contact, phone, mail for transporter N", async () => {
+      // Given
+      const emitter = await userWithCompanyFactory("ADMIN");
+      const transporter1 = await userWithCompanyFactory("ADMIN");
+      const transporter2 = await userWithCompanyFactory("ADMIN");
+      await transporterReceiptFactory({ company: transporter1.company });
+      await transporterReceiptFactory({ company: transporter2.company });
+
+      const emittedAt = new Date("2018-12-11T00:00:00.000Z");
+      const takenOverAt = new Date("2018-12-12T00:00:00.000Z");
+      const form = await formFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          status: "SENT",
+          emitterCompanySiret: emitter.company.siret,
+          emitterCompanyName: emitter.company.name,
+          signedByTransporter: null,
+          sentAt: emittedAt,
+          sentBy: emitter.user.name,
+          takenOverAt,
+          takenOverBy: transporter1.user.name,
+          emittedAt: emittedAt,
+          emittedBy: emitter.user.name,
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter1.company.siret,
+              takenOverAt: new Date("2018-12-12T00:00:00.000Z"),
+              takenOverBy: transporter1.user.name,
+              transporterCompanyContact: "Old contact 1",
+              transporterCompanyMail: "old.email1@mail.com",
+              transporterCompanyPhone: "0102030401",
+              number: 1
+            }
+          }
+        }
+      });
+
+      await bsddTransporterFactory({
+        formId: form.id,
+        opts: {
+          transporterCompanySiret: transporter2.company.siret,
+          transporterCompanyContact: "Old contact 2",
+          transporterCompanyMail: "old.email2@mail.com",
+          transporterCompanyPhone: "0102030402"
+        }
+      });
+
+      // When
+      const { mutate } = makeClient(transporter2.user);
+      const { errors } = await mutate<
+        Pick<Mutation, "signTransportForm">,
+        MutationSignTransportFormArgs
+      >(SIGN_TRANSPORT_FORM, {
+        variables: {
+          id: form.id,
+          input: {
+            takenOverAt: takenOverAt.toISOString() as any,
+            takenOverBy: transporter2.user.name,
+            transporterCompanyContact: "New contact 2",
+            transporterCompanyMail: "new.email2@mail.com",
+            transporterCompanyPhone: "010505050505"
+          }
+        }
+      });
+
+      // Then
+      expect(errors).toBeUndefined();
+
+      const updatedForm = await prisma.form.findFirstOrThrow({
+        where: { id: form.id },
+        include: { transporters: true }
+      });
+
+      const transporters = getTransportersSync(updatedForm);
+
+      // Transporter 1 should not have been updated
+      expect(transporters[0].transporterCompanyContact).toEqual(
+        "Old contact 1"
+      );
+      expect(transporters[0].transporterCompanyMail).toEqual(
+        "old.email1@mail.com"
+      );
+      expect(transporters[0].transporterCompanyPhone).toEqual("0102030401");
+
+      // Transporter 2 should have been updated
+      expect(transporters[1].transporterCompanyContact).toEqual(
+        "New contact 2"
+      );
+      expect(transporters[1].transporterCompanyMail).toEqual(
+        "new.email2@mail.com"
+      );
+      expect(transporters[1].transporterCompanyPhone).toEqual("010505050505");
+
+      expect(updatedForm.currentTransporterOrgId).toEqual(
+        transporter2.company.siret
+      );
     });
   });
 });

--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -156,6 +156,21 @@ const signTransportFn = async (
           transporterTransportMode: args.input.transporterTransportMode
         }
       : {}),
+    ...(args.input.transporterCompanyContact
+      ? {
+          transporterCompanyContact: args.input.transporterCompanyContact
+        }
+      : {}),
+    ...(args.input.transporterCompanyMail
+      ? {
+          transporterCompanyMail: args.input.transporterCompanyMail
+        }
+      : {}),
+    ...(args.input.transporterCompanyPhone
+      ? {
+          transporterCompanyPhone: args.input.transporterCompanyPhone
+        }
+      : {}),
     ...receiptFields
   };
 

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -64,6 +64,11 @@ input SignTransportFormInput {
 
   "Le mode de transport utilisé par le transporteur"
   transporterTransportMode: TransportMode
+
+  "Coordonnées de l'entreprise de transport (contact, mail, téléphone)"
+  transporterCompanyContact: String
+  transporterCompanyMail: String
+  transporterCompanyPhone: String
 }
 
 "Payload de signature d'un BSD par un transporteur"

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormTransporterInfo.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormTransporterInfo.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { Maybe, Transporter } from "@td/codegen-ui";
+import { Field } from "formik";
+import { RedErrorMessage } from "../../../../../common/components";
+
+interface FormTransporterInfoProps {
+  transporter: Maybe<Transporter> | undefined;
+}
+
+export function FormTransporterInfo({ transporter }: FormTransporterInfoProps) {
+  //   const { values, setFieldValue } = useFormikContext<FormValues>();
+
+  if (!transporter) return null;
+
+  return (
+    <>
+      <div className="form__row">
+        <label>
+          Personne à contacter
+          <div className="td-date-wrapper">
+            <Field
+              className="td-input"
+              name="transporterCompanyContact"
+              placeholder="NOM Prénom"
+              style={{ minWidth: 200 }}
+            />
+          </div>
+        </label>
+        <RedErrorMessage name="transporterCompanyContact" />
+      </div>
+
+      <div className="fr-grid-row fr-grid-row--gutters">
+        <div className="fr-col-6">
+          <div className="form__row">
+            <label>
+              Téléphone
+              <Field
+                className="td-input"
+                name="transporterCompanyPhone"
+                placeholder="Téléphone"
+              />
+            </label>
+            <RedErrorMessage name="transporterCompanyPhone" />
+          </div>
+        </div>
+
+        <div className="fr-col-6">
+          <div className="form__row">
+            <label>
+              Courriel
+              <Field
+                className="td-input"
+                name="transporterCompanyMail"
+                placeholder="exemple@mail.com"
+              />
+            </label>
+            <RedErrorMessage name="transporterCompanyMail" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
@@ -31,6 +31,7 @@ import {
 } from "../../../../../Apps/common/queries/bsdd/queries";
 import { cleanPackagings } from "../../../../../Apps/Forms/Components/PackagingList/helpers";
 import { packagingInfo } from "../../../../../form/bsdd/utils/schema";
+import { FormTransporterInfo } from "./FormTransporterInfo";
 
 const validationSchema = yup.object({
   takenOverAt: yup.date().required("La date de prise en charge est requise"),
@@ -42,6 +43,9 @@ const validationSchema = yup.object({
     .string()
     .nullable()
     .matches(/[0-9]{4}/, "Le code de signature est composé de 4 chiffres"),
+  transporterCompanyContact: yup.string().max(250),
+  transporterCompanyPhone: yup.string().max(20),
+  transporterCompanyMail: yup.string().max(250).email(),
   update: yup.object({ packagingInfos: yup.array().of(packagingInfo) })
 });
 interface SignTransportFormModalProps {
@@ -132,6 +136,8 @@ export default function SignTransportFormModalContent({
 
   const TODAY = new Date();
 
+  console.log("form", form);
+
   return (
     <Formik
       initialValues={{
@@ -140,6 +146,9 @@ export default function SignTransportFormModalContent({
         securityCode: "",
         transporterNumberPlate: signingTransporter?.numberPlate ?? "",
         transporterTransportMode: signingTransporter?.mode ?? null,
+        transporterCompanyContact: signingTransporter?.company?.contact ?? "",
+        transporterCompanyMail: signingTransporter?.company?.mail ?? "",
+        transporterCompanyPhone: signingTransporter?.company?.phone ?? "",
         emitter: { type: form?.emitter?.type },
         update: {
           quantity: form.wasteDetails?.quantity ?? 0,
@@ -183,7 +192,10 @@ export default function SignTransportFormModalContent({
                 takenOverBy: values.takenOverBy,
                 transporterNumberPlate: values.transporterNumberPlate,
                 transporterTransportMode:
-                  values.transporterTransportMode as TransportMode
+                  values.transporterTransportMode as TransportMode,
+                transporterCompanyContact: values.transporterCompanyContact,
+                transporterCompanyMail: values.transporterCompanyMail,
+                transporterCompanyPhone: values.transporterCompanyPhone
               },
               securityCode: values.securityCode
                 ? Number(values.securityCode)
@@ -208,6 +220,8 @@ export default function SignTransportFormModalContent({
             les informations ci-dessus sont correctes. En signant ce document,
             je déclare prendre en charge le déchet.
           </p>
+
+          <FormTransporterInfo transporter={signingTransporter} />
 
           <div className="form__row">
             <label>


### PR DESCRIPTION
# Contexte

On veut donner la possibilité au transporteur , sur les BSDD, de modifier ses informations au moment de sa signature.

# Points de vigilance pour les intégrateurs

Il est possible de passer les champs dans la mutation `signTransportForm`, mais les champs sont optionnels (pas de breaking change).

# Démo

<img width="3158" height="1672" alt="image" src="https://github.com/user-attachments/assets/f2cd5296-35a9-4845-b2fd-493cb9eaa12a" />

# Ticket Favro

[Permettre au transporteur de modifier ses champs de contact ainsi que le mode de transport à sa signature sur un BSDD ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-17181)
