### PR TITLE
[HOTFIX - TRA 18002] afficher la bonne action de signature de contenant BSFF

### DIFF
--- a/front/src/Apps/Dashboard/Validation/bsff/SignBsffPackagingForm.tsx
+++ b/front/src/Apps/Dashboard/Validation/bsff/SignBsffPackagingForm.tsx
@@ -266,7 +266,8 @@ function getSchema(packaging: BsffPackaging) {
 function getSignatureType(packaging: BsffPackaging): BsffSignatureType | null {
   if (
     packaging?.operation?.signature?.date ||
-    packaging?.acceptation?.status === WasteAcceptationStatus.Refused
+    (!!packaging.acceptation?.signature?.date &&
+      packaging?.acceptation?.status === WasteAcceptationStatus.Refused)
   ) {
     return null;
   }


### PR DESCRIPTION
# Contexte

Dans le cas où les infos d'acceptation d'un contenant BSFF sont déjà remplies mais pas signées, le formulaire d'acceptation n'affichait pas les champs de signature ni le bon bouton de soumission du formulaire. Je prends donc en compte la présence de la signature (comme pour l'affichage du wording des boutons dans [SignBsffPackagingsModal.tsx](https://github.com/MTES-MCT/trackdechets/blob/273e87ee8da00d93f2475570221e6397e6872c41/front/src/Apps/Dashboard/Validation/bsff/SignBsffPackagingsModal.tsx#L31-L57) ).

Le cas où ces infos sont remplies sans qu'il n'y ait de signature n'est pas trop possible normalement, mais peut arriver dans le cas où il y aurait par exemple une erreur au moment de la signature, vu que les infos sont ajoutées avant dans une mutation updateBsff.

# Points de vigilance pour les intégrateurs

X

# Démo

X

# Ticket Favro

[BSFF : impossibilité de signer l’acceptation - Bouton "corriger' inactif sur la modale](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-18002)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB