### PR TITLE
[TRA-17903]-fix: Rediriger correctement l'utilisateur à la fermeture d'un BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Preview/BSDPreviewTabs.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSDPreviewTabs.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Tabs } from "@codegouvfr/react-dsfr/Tabs";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { FrIconClassName, RiIconClassName } from "@codegouvfr/react-dsfr";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 const getNextTab = (tabIds: string[], currentTabId: string) => {
   const idx = tabIds.indexOf(currentTabId);
@@ -48,6 +48,8 @@ const BSDPreviewTabs = ({
   const onTabChange = tabId => {
     setSelectedTabId(tabId);
   };
+
+  const { siret } = useParams<{ siret: string }>();
 
   return (
     <>
@@ -110,7 +112,7 @@ const BSDPreviewTabs = ({
               <Button
                 id="id_close"
                 priority="primary"
-                onClick={() => navigate(-1)}
+                onClick={() => navigate(`/dashboard/${siret}/bsds/all`)}
               >
                 Fermer
               </Button>


### PR DESCRIPTION
# Contexte

 Si on envoie un lien direct vers un BSDA sur le site (sandbox du moins), après authentification, la modale décrivant le BSDA s’affiche bien. Mais quand on clique sur le bouton « Fermer », on est redirigé vers la page de connexion.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo
[Screencast from 2026-03-16 04-13-01.webm](https://github.com/user-attachments/assets/b7f19084-ba8a-4aa6-97ec-c1e8fef003cf)
=
# Ticket Favro

[TRA-17903] (https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-17903)

# Checklist

- [ - ] Mettre à jour la documentation
- [ - ] Mettre à jour le change log
- [ - ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ - ] Informer le data engineer de tout changement de schéma DB