### PR TITLE
[TRA-15360] ETQ utilisateur je ne peux pas créer un BSFF avec un siret fermé, mais je peux finaliser un BSFF avec un siret fermé

### DIFF
--- a/back/src/bsffs/resolvers/mutations/__tests__/createBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/createBsff.integration.ts
@@ -1,4 +1,10 @@
-import { BsffPackagingType, BsffType, Company, User, UserRole } from "@td/prisma";
+import {
+  BsffPackagingType,
+  BsffType,
+  Company,
+  User,
+  UserRole
+} from "@td/prisma";
 import { gql } from "graphql-tag";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { BSFF_WASTE_CODES } from "@td/constants";

--- a/back/src/bsffs/resolvers/mutations/__tests__/createBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/createBsff.integration.ts
@@ -1,16 +1,18 @@
-import { BsffPackagingType, BsffType, UserRole } from "@td/prisma";
+import { BsffPackagingType, BsffType, Company, User, UserRole } from "@td/prisma";
 import { gql } from "graphql-tag";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { BSFF_WASTE_CODES } from "@td/constants";
 import type {
   Mutation,
   MutationCreateBsffArgs,
-  BsffOperationCode
+  BsffOperationCode,
+  BsffInput
 } from "@td/codegen-back";
 import {
   siretify,
   userWithCompanyFactory,
-  transporterReceiptFactory
+  transporterReceiptFactory,
+  companyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { fullBsff } from "../../../fragments";
@@ -80,7 +82,7 @@ const createInput = (emitter, transporter, destination) => ({
 });
 
 describe("Mutation.createBsff", () => {
-  afterEach(resetDatabase);
+  afterAll(resetDatabase);
 
   it("should allow user to create a bsff", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
@@ -503,5 +505,203 @@ describe("Mutation.createBsff", () => {
           "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
       })
     ]);
+  });
+
+  describe("dormant sirets", () => {
+    let user: User;
+    let emitter: Company;
+    let destination: Company;
+    let transporter: Company;
+    let bsffInput: BsffInput;
+
+    // eslint-disable-next-line prefer-const
+    let searchCompanyMock = jest.fn().mockReturnValue({});
+    let makeClientLocal: typeof makeClient;
+
+    beforeAll(async () => {
+      const emitterCompanyAndUser = await userWithCompanyFactory("MEMBER", {
+        name: "Emitter"
+      });
+      user = emitterCompanyAndUser.user;
+      emitter = emitterCompanyAndUser.company;
+      destination = await companyFactory({ name: "Destination" });
+      transporter = await companyFactory({ name: "Transporter" });
+
+      bsffInput = {
+        type: BsffType.COLLECTE_PETITES_QUANTITES,
+        emitter: {
+          company: {
+            siret: emitter.siret,
+            name: emitter.name,
+            address: "Rue de la carcasse",
+            contact: "Contact emitter",
+            phone: "0101010101",
+            mail: "emitter@mail.com"
+          }
+        },
+        transporter: {
+          company: {
+            siret: transporter.siret,
+            name: transporter.name,
+            address: "address",
+            contact: "contact",
+            phone: "0101010101",
+            mail: "transporter@mail.com"
+          }
+        },
+        destination: {
+          company: {
+            siret: destination.siret,
+            name: destination.name,
+            address: "address",
+            contact: "contact",
+            phone: "0101010101",
+            mail: "destination@mail.com"
+          },
+          plannedOperationCode: "R12" as BsffOperationCode
+        },
+        waste: {
+          code: BSFF_WASTE_CODES[0],
+          adr: "Mention ADR",
+          description: "R410"
+        },
+        weight: {
+          value: 1,
+          isEstimate: true
+        },
+        packagings: [
+          {
+            type: BsffPackagingType.BOUTEILLE,
+            numero: "123",
+            weight: 1,
+            volume: 1
+          }
+        ]
+      };
+
+      // Mock les appels à la base SIRENE
+      jest.mock("../../../../companies/search", () => ({
+        // https://www.chakshunyu.com/blog/how-to-mock-only-one-function-from-a-module-in-jest/
+        ...jest.requireActual("../../../../companies/search"),
+        searchCompany: searchCompanyMock
+      }));
+
+      // Ré-importe makeClient pour que searchCompany soit bien mocké
+      jest.resetModules();
+      makeClientLocal = require("../../../../__tests__/testClient")
+        .default as typeof makeClient;
+    });
+
+    afterAll(async () => {
+      jest.resetAllMocks();
+      await resetDatabase();
+    });
+
+    describe("closed company", () => {
+      const mockCloseCompany = (siretToClose: string | null) => {
+        searchCompanyMock.mockImplementation((siret: string) => {
+          return {
+            siret,
+            etatAdministratif: siret === siretToClose ? "F" : "O",
+            address: "Company address",
+            name: "Company name"
+          };
+        });
+      };
+
+      const testCreatingBsffWithClosedSiret = async (
+        siret: string | null | undefined
+      ) => {
+        // Given
+        mockCloseCompany(siret!);
+
+        // When
+        const { mutate } = makeClientLocal(user);
+        const { errors } = await mutate<Pick<Mutation, "createBsff">>(
+          CREATE_BSFF,
+          {
+            variables: {
+              input: bsffInput
+            }
+          }
+        );
+
+        // Then
+        expect(errors).not.toBeUndefined();
+        expect(errors[0].message).toBe(
+          `L'établissement ${siret} est fermé selon le répertoire SIRENE`
+        );
+      };
+
+      it.each(["emitter", "transporter", "destination"])(
+        "should not allow creating a BSFF with a closed %p siret",
+        async role => {
+          const siret = bsffInput?.[role]?.company?.siret;
+          await testCreatingBsffWithClosedSiret(siret);
+        }
+      );
+    });
+
+    describe("dormant company", () => {
+      const mockOpenCompany = () => {
+        searchCompanyMock.mockImplementation((siret: string) => {
+          return {
+            siret,
+            etatAdministratif: "O",
+            address: "Company address",
+            name: "Company name"
+          };
+        });
+      };
+
+      const testCreatingBsffWithDormantSiret = async (
+        siret: string | null | undefined
+      ) => {
+        // Given
+        mockOpenCompany();
+
+        // Reset previous companies
+        await prisma.company.updateMany({
+          data: {
+            isDormantSince: null
+          }
+        });
+
+        // Make target company go dormant
+        await prisma.company.update({
+          where: {
+            siret: siret!
+          },
+          data: {
+            isDormantSince: new Date()
+          }
+        });
+
+        // When
+        const { mutate } = makeClientLocal(user);
+        const { errors } = await mutate<Pick<Mutation, "createBsff">>(
+          CREATE_BSFF,
+          {
+            variables: {
+              input: bsffInput
+            }
+          }
+        );
+
+        // Then
+        expect(errors).not.toBeUndefined();
+        expect(errors[0].message).toBe(
+          `L'établissement avec le SIRET ${siret} est en sommeil sur Trackdéchets, il n'est pas possible de le mentionner sur un bordereau`
+        );
+      };
+
+      it.each(["emitter", "transporter", "destination"])(
+        "should not allow creating a BSFF with a dormant %p siret",
+        async role => {
+          const siret = bsffInput?.[role]?.company?.siret;
+          await testCreatingBsffWithDormantSiret(siret);
+        }
+      );
+    });
   });
 });

--- a/back/src/bsffs/resolvers/mutations/__tests__/publishBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/publishBsff.integration.ts
@@ -37,28 +37,38 @@ describe("publishBsff", () => {
       MutationPublishBsffArgs
     >(PUBLISH_BSFF, { variables: { id: bsff.id } });
 
-    expect(errors).toEqual([
-      expect.objectContaining({
-        message:
-          "La raison sociale de l'émetteur est un champ requis.\n" +
-          "L'adresse de l'émetteur est un champ requis.\n" +
-          "La personne à contacter chez l'émetteur est un champ requis.\n" +
-          "Le N° de téléphone de l'émetteur est un champ requis.\n" +
-          "L'adresse e-mail de l'émetteur est un champ requis.\n" +
-          "Le code déchet est un champ requis.\n" +
-          "La description du déchet est un champ requis.\n" +
-          "L'ADR est un champ requis.\n" +
-          "La quantité totale est un champ requis.\n" +
-          "La raison sociale de l'installation de destination est un champ requis.\n" +
-          "Le SIRET de l'installation de destination est un champ requis.\n" +
-          "L'adresse de l'installation de destination est un champ requis.\n" +
-          "La personne à contacter de l'installation de destination est un champ requis.\n" +
-          "Le N° de téléphone de l'installation de destination est un champ requis.\n" +
-          "Le code d'opération prévu est un champ requis.\n" +
-          "L'adresse e-mail de l'installation de destination est un champ requis.\n" +
-          "La liste des contenants est un champ requis."
-      })
-    ]);
+    expect(errors).toHaveLength(1);
+
+    const error = errors![0];
+
+    // CAST LOCAL, SIMPLE
+    const issues = (
+      error.extensions as {
+        issues: { message: string }[];
+      }
+    ).issues;
+
+    const messages = issues.map(i => i.message);
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        "La personne à contacter chez l'émetteur est un champ requis.",
+        "Le N° de téléphone de l'émetteur est un champ requis.",
+        "L'adresse e-mail de l'émetteur est un champ requis.",
+        "Le code déchet est un champ requis.",
+        "La description du déchet est un champ requis.",
+        "L'ADR est un champ requis.",
+        "La quantité totale est un champ requis.",
+        "La raison sociale de l'installation de destination est un champ requis.",
+        "Le SIRET de l'installation de destination est un champ requis.",
+        "L'adresse de l'installation de destination est un champ requis.",
+        "La personne à contacter de l'installation de destination est un champ requis.",
+        "Le N° de téléphone de l'installation de destination est un champ requis.",
+        "Le code d'opération prévu est un champ requis.",
+        "L'adresse e-mail de l'installation de destination est un champ requis.",
+        "La liste des contenants est un champ requis."
+      ])
+    );
   });
 
   it("should publish a valid BSFF", async () => {

--- a/back/src/bsffs/resolvers/mutations/__tests__/signBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/signBsff.integration.ts
@@ -17,6 +17,7 @@ import type {
 import { prisma } from "@td/prisma";
 import {
   UserWithCompany,
+  companyFactory,
   transporterReceiptFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
@@ -39,6 +40,18 @@ import {
 import { operationHooksQueue } from "../../../../queue/producers/operationHook";
 import { getTransportersSync } from "../../../database";
 import { UPDATE_BSFF } from "./updateBsff.integration";
+
+// Mock searchCompany for dormant/closed company tests.
+// The mock defaults to jest.fn() (returns undefined), which makes
+// searchCompanyFailFast return null, effectively skipping sirenify.
+jest.mock("../../../../companies/search", () => ({
+  ...jest.requireActual("../../../../companies/search"),
+  searchCompany: jest.fn()
+}));
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { searchCompany: mockSearchCompany } = require(
+  "../../../../companies/search"
+) as { searchCompany: jest.Mock };
 
 const SIGN = gql`
   mutation Sign($id: ID!, $input: BsffSignatureInput!) {
@@ -1531,5 +1544,224 @@ describe("Mutation.signBsff", () => {
         expect(newBsff2.status).toEqual(BsffStatus.PROCESSED);
       }
     );
+  });
+
+  describe("dormant sirets", () => {
+    afterEach(() => {
+      mockSearchCompany.mockReset();
+    });
+
+    const createUserAndBsff = async (
+      input: Partial<{
+        status: BsffStatus;
+        emitterEmissionSignatureDate: Date;
+        emitterEmissionSignatureAuthor: string;
+      }> = {}
+    ) => {
+      const emitterCompanyAndUser = await userWithCompanyFactory("MEMBER", {
+        name: "Emitter"
+      });
+      const transporterCompanyAndUser = await userWithCompanyFactory("MEMBER", {
+        name: "Transporter"
+      });
+      await transporterReceiptFactory({
+        company: transporterCompanyAndUser.company
+      });
+      const destination = await companyFactory({ name: "Destination" });
+
+      const bsff = await createBsffBeforeEmission(
+        {
+          emitter: emitterCompanyAndUser,
+          destination: {
+            company: destination,
+            user: emitterCompanyAndUser.user
+          },
+          transporter: transporterCompanyAndUser
+        },
+        {
+          data: {
+            ...input
+          },
+          transporterData: {
+            transporterTransportMode: TransportMode.ROAD,
+            transporterTransportPlates: ["AA-123-BB"]
+          }
+        }
+      );
+
+      return {
+        user: emitterCompanyAndUser.user,
+        transporterUser: transporterCompanyAndUser.user,
+        bsff
+      };
+    };
+
+    it("should not be able to sign if a siret is closed", async () => {
+      // In this example the emitter is closed, so he shouldn't
+      // be able to sign the EMISSION step
+
+      // Given
+      const { user, bsff } = await createUserAndBsff();
+
+      mockSearchCompany.mockImplementation((siret: string) =>
+        Promise.resolve({
+          siret,
+          etatAdministratif:
+            siret === bsff.emitterCompanySiret ? "F" : "O",
+          address: "Company address",
+          name: "Company name"
+        })
+      );
+
+      // When
+      const { mutate } = makeClient(user);
+      const { errors } = await mutate<
+        Pick<Mutation, "signBsff">,
+        MutationSignBsffArgs
+      >(SIGN, {
+        variables: {
+          id: bsff.id,
+          input: {
+            author: user.name,
+            type: "EMISSION"
+          }
+        }
+      });
+
+      // Then
+      expect(errors).not.toBeUndefined();
+      expect(errors[0].message).toBe(
+        `L'établissement ${bsff.emitterCompanySiret} est fermé selon le répertoire SIRENE`
+      );
+    });
+
+    it("should be able to sign if a siret is closed but field is sealed", async () => {
+      // In this example the emitter has closed but it's ok because
+      // EMISSION has already been signed. The transporter can go on with
+      // the workflow
+
+      // Given
+      const { transporterUser, bsff } = await createUserAndBsff({
+        emitterEmissionSignatureDate: new Date(),
+        emitterEmissionSignatureAuthor: "Emitter",
+        status: BsffStatus.SIGNED_BY_EMITTER
+      });
+
+      mockSearchCompany.mockImplementation((siret: string) =>
+        Promise.resolve({
+          siret,
+          etatAdministratif:
+            siret === bsff.emitterCompanySiret ? "F" : "O",
+          address: "Company address",
+          name: "Company name"
+        })
+      );
+
+      // When
+      const { mutate } = makeClient(transporterUser);
+      const { errors } = await mutate<
+        Pick<Mutation, "signBsff">,
+        MutationSignBsffArgs
+      >(SIGN, {
+        variables: {
+          id: bsff.id,
+          input: {
+            author: transporterUser.name,
+            type: "TRANSPORT"
+          }
+        }
+      });
+
+      // Then
+      expect(errors).toBeUndefined();
+    });
+
+    it("should not be able to sign if a siret is dormant", async () => {
+      // In this example the emitter is dormant, so he shouldn't
+      // be able to sign the EMISSION step
+
+      // Given
+      const { user, bsff } = await createUserAndBsff();
+
+      mockSearchCompany.mockImplementation((siret: string) =>
+        Promise.resolve({
+          siret,
+          etatAdministratif: "O",
+          address: "Company address",
+          name: "Company name"
+        })
+      );
+
+      await prisma.company.update({
+        where: { siret: bsff.emitterCompanySiret! },
+        data: { isDormantSince: new Date() }
+      });
+
+      // When
+      const { mutate } = makeClient(user);
+      const { errors } = await mutate<
+        Pick<Mutation, "signBsff">,
+        MutationSignBsffArgs
+      >(SIGN, {
+        variables: {
+          id: bsff.id,
+          input: {
+            author: user.name,
+            type: "EMISSION"
+          }
+        }
+      });
+
+      // Then
+      expect(errors).not.toBeUndefined();
+      expect(errors[0].message).toBe(
+        `L'établissement avec le SIRET ${bsff.emitterCompanySiret} est en sommeil sur Trackdéchets, il n'est pas possible de le mentionner sur un bordereau`
+      );
+    });
+
+    it("should be able to sign if a siret is dormant but field is sealed", async () => {
+      // In this example the emitter has gone dormant but it's ok because
+      // EMISSION has already been signed. The transporter can go on with
+      // the workflow
+
+      // Given
+      const { transporterUser, bsff } = await createUserAndBsff({
+        emitterEmissionSignatureDate: new Date(),
+        emitterEmissionSignatureAuthor: "Emitter",
+        status: BsffStatus.SIGNED_BY_EMITTER
+      });
+
+      mockSearchCompany.mockImplementation((siret: string) =>
+        Promise.resolve({
+          siret,
+          etatAdministratif: "O",
+          address: "Company address",
+          name: "Company name"
+        })
+      );
+
+      await prisma.company.update({
+        where: { siret: bsff.emitterCompanySiret! },
+        data: { isDormantSince: new Date() }
+      });
+
+      // When
+      const { mutate } = makeClient(transporterUser);
+      const { errors } = await mutate<
+        Pick<Mutation, "signBsff">,
+        MutationSignBsffArgs
+      >(SIGN, {
+        variables: {
+          id: bsff.id,
+          input: {
+            author: transporterUser.name,
+            type: "TRANSPORT"
+          }
+        }
+      });
+
+      // Then
+      expect(errors).toBeUndefined();
+    });
   });
 });

--- a/back/src/bsffs/resolvers/mutations/__tests__/signBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/signBsff.integration.ts
@@ -49,9 +49,8 @@ jest.mock("../../../../companies/search", () => ({
   searchCompany: jest.fn()
 }));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { searchCompany: mockSearchCompany } = require(
-  "../../../../companies/search"
-) as { searchCompany: jest.Mock };
+const { searchCompany: mockSearchCompany } =
+  require("../../../../companies/search") as { searchCompany: jest.Mock };
 
 const SIGN = gql`
   mutation Sign($id: ID!, $input: BsffSignatureInput!) {
@@ -1606,8 +1605,7 @@ describe("Mutation.signBsff", () => {
       mockSearchCompany.mockImplementation((siret: string) =>
         Promise.resolve({
           siret,
-          etatAdministratif:
-            siret === bsff.emitterCompanySiret ? "F" : "O",
+          etatAdministratif: siret === bsff.emitterCompanySiret ? "F" : "O",
           address: "Company address",
           name: "Company name"
         })
@@ -1650,8 +1648,7 @@ describe("Mutation.signBsff", () => {
       mockSearchCompany.mockImplementation((siret: string) =>
         Promise.resolve({
           siret,
-          etatAdministratif:
-            siret === bsff.emitterCompanySiret ? "F" : "O",
+          etatAdministratif: siret === bsff.emitterCompanySiret ? "F" : "O",
           address: "Company address",
           name: "Company name"
         })

--- a/back/src/bsffs/validation/bsff/refinements.ts
+++ b/back/src/bsffs/validation/bsff/refinements.ts
@@ -15,6 +15,7 @@ import {
   bsffEditionRules,
   bsffPackagingEditionRules,
   bsffTransporterEditionRules,
+  getSealedFields,
   isBsffFieldRequired,
   isBsffPackagingFieldRequired,
   isBsffTransporterFieldRequired
@@ -38,6 +39,7 @@ import {
   isRegisteredVatNumberRefinement,
   isTransporterRefinement
 } from "../../../common/validation/zod/refinement";
+import { CompanyRole } from "../../../common/validation/zod/schema";
 import { MAX_WEIGHT_BY_ROAD_TONNES } from "../../../common/validation";
 
 // Date de la MAJ 2024.07.1 introduisant un changement
@@ -53,12 +55,28 @@ const v2024091 = new Date("2024-09-24");
  * Ce refinement permet de vérifier que les établissements présents sur le
  * BSFF sont bien inscrits sur Trackdéchets avec le bon profil
  */
-export const checkCompanies: Refinement<ParsedZodBsff> = async (
-  bsff,
-  zodContext
+export const checkCompanies = async (
+  bsff: ParsedZodBsff,
+  zodContext: RefinementCtx,
+  bsffValidationContext: BsffValidationContext
 ) => {
-  await isEmitterRefinement(bsff.emitterCompanySiret, BsdType.BSFF, zodContext);
-  await isDestinationRefinement(bsff.destinationCompanySiret, zodContext);
+  const sealedFields = await getSealedFields(bsff, bsffValidationContext);
+
+  await isEmitterRefinement(
+    bsff.emitterCompanySiret,
+    BsdType.BSFF,
+    zodContext,
+    false,
+    !sealedFields.includes("emitterCompanySiret")
+  );
+  await isDestinationRefinement(
+    bsff.destinationCompanySiret,
+    zodContext,
+    "DESTINATION",
+    CompanyRole.Destination,
+    undefined,
+    !sealedFields.includes("destinationCompanySiret")
+  );
 
   for (const transporter of bsff.transporters ?? []) {
     await isTransporterRefinement(
@@ -67,7 +85,8 @@ export const checkCompanies: Refinement<ParsedZodBsff> = async (
         transporterRecepisseIsExempted:
           transporter.transporterRecepisseIsExempted ?? false
       },
-      zodContext
+      zodContext,
+      !sealedFields.includes("transporters")
     );
     await isRegisteredVatNumberRefinement(
       transporter.transporterCompanyVatNumber,

--- a/back/src/bsffs/validation/bsff/rules.ts
+++ b/back/src/bsffs/validation/bsff/rules.ts
@@ -702,8 +702,7 @@ export async function checkBsffSealedFields(
 
   const updatedFields = getUpdatedFields(persisted, bsff);
 
-  const currentSignatureType =
-    context.currentSignatureType ?? getCurrentSignatureType(persisted);
+  const currentSignatureType = getCurrentSignatureType(persisted);
 
   // Some signatures may be skipped, so always check all the hierarchy
   const signaturesToCheck = getSignatureAncestors(currentSignatureType);
@@ -820,8 +819,7 @@ export async function getSealedFields(
   bsff: ZodBsff,
   context: BsffValidationContext
 ): Promise<(keyof BsffEditionRules)[]> {
-  const currentSignatureType =
-    context.currentSignatureType ?? getCurrentSignatureType(bsff);
+  const currentSignatureType = getCurrentSignatureType(bsff);
   // Some signatures may be skipped, so always check all the hierarchy
   const signaturesToCheck = getSignatureAncestors(currentSignatureType);
 

--- a/back/src/bsffs/validation/bsff/schema.ts
+++ b/back/src/bsffs/validation/bsff/schema.ts
@@ -207,7 +207,9 @@ export const contextualBsffSchema = (context: BsffValidationContext) => {
  */
 export const contextualBsffSchemaAsync = (context: BsffValidationContext) => {
   return refinedBsffSchema
-    .superRefine(checkCompanies)
+    .superRefine((bsff, zodContext) =>
+      checkCompanies(bsff, zodContext, context)
+    )
     .transform((bsff: ParsedZodBsff) => runTransformers(bsff, context))
     .superRefine(
       // run le check sur les champs requis après les transformations


### PR DESCRIPTION
# Contexte

Suite du travail qui a été fait sur le BSDA: https://github.com/MTES-MCT/trackdechets/pull/3761

# Ticket Favro

[Ne pas permettre de viser un SIRET fermé sur un bordereau, mais permettre de finaliser un BSFF qui aurait un SIRET fermé - BSFF (BUG : impossible de signer la réception ou créer un BSFF suite après la fermeture d'un établissement)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15360)
