### PR TITLE
[TRA-18014] Correction d'un bug de mise à jour sur le VHU avec plusieurs transporteurs

### DIFF
--- a/back/src/bsvhu/resolvers/mutations/__tests__/updateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/updateBsvhu.integration.ts
@@ -942,6 +942,73 @@ describe("Mutation.Vhu.update", () => {
     expect(updatedBsvhu.containsElectricOrHybridVehicles).toBeTruthy();
   });
 
+  it(
+    "should not raise sealed field error when updating a signed BSVHU" +
+      " with the same transporter IDs",
+    async () => {
+      // Given: a BSVHU signed by the producer with two transporters
+      const emitter = await userWithCompanyFactory("ADMIN");
+      const transporter1Company = await companyFactory({
+        companyTypes: ["TRANSPORTER"]
+      });
+      await transporterReceiptFactory({ company: transporter1Company });
+      const transporter2Company = await companyFactory({
+        companyTypes: ["TRANSPORTER"]
+      });
+      await transporterReceiptFactory({ company: transporter2Company });
+
+      const bsvhu = await bsvhuFactory({
+        userId: emitter.user.id,
+        opt: {
+          status: BsvhuStatus.SIGNED_BY_PRODUCER,
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureAuthor: "The Emitter",
+          emitterEmissionSignatureDate: new Date(),
+          transporters: {
+            createMany: {
+              data: [
+                {
+                  number: 1,
+                  transporterCompanySiret: transporter1Company.siret
+                },
+                {
+                  number: 2,
+                  transporterCompanySiret: transporter2Company.siret
+                }
+              ]
+            }
+          }
+        }
+      });
+
+      const transporters = await prisma.bsvhuTransporter.findMany({
+        where: { bsvhuId: bsvhu.id },
+        orderBy: { number: "asc" }
+      });
+
+      expect(transporters).toHaveLength(2);
+
+      // When: we "update" the BSVHU passing the exact same transporter IDs
+      // (this is what the frontend does when saving without touching transporter fields)
+      const { mutate } = makeClient(emitter.user);
+      const { data, errors } = await mutate<Pick<Mutation, "updateBsvhu">>(
+        UPDATE_VHU_FORM,
+        {
+          variables: {
+            id: bsvhu.id,
+            input: {
+              transporters: transporters.map(t => t.id)
+            }
+          }
+        }
+      );
+
+      // Then: no sealed field error should occur
+      expect(errors).toBeUndefined();
+      expect(data.updateBsvhu.id).toBe(bsvhu.id);
+    }
+  );
+
   it("should not allow user to update containsElectricOrHybridVehicles if VHU is processed", async () => {
     // Given
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);

--- a/back/src/bsvhu/validation/helpers.ts
+++ b/back/src/bsvhu/validation/helpers.ts
@@ -14,6 +14,7 @@ import { safeInput } from "../../common/converter";
 import { objectDiff } from "../../forms/workflow/diff";
 import { AllBsvhuSignatureType } from "../types";
 import { UserInputError } from "../../common/errors";
+import { getTransportersSync } from "../database";
 
 export function graphqlInputToZodBsvhuTransporter(
   input: BsvhuTransporterInput
@@ -126,6 +127,7 @@ export function prismaToZodBsvhu(bsvhu: PrismaBsvhuForParsing): ZodBsvhu {
     destinationPlannedOperationCode,
     destinationOperationCode,
     intermediaries,
+    transporters,
     ...data
   } = bsvhu;
 
@@ -138,6 +140,10 @@ export function prismaToZodBsvhu(bsvhu: PrismaBsvhuForParsing): ZodBsvhu {
     intermediaries: intermediaries.map(i => {
       const { bsvhuId, id, createdAt, ...intermediaryData } = i;
       return { ...intermediaryData, address: intermediaryData.address! };
+    }),
+    transporters: getTransportersSync({ transporters }).map(t => {
+      const { createdAt, updatedAt, number, ...transporterData } = t;
+      return transporterData;
     })
   };
 }


### PR DESCRIPTION
# Contexte

Petit bug qui fait qu'on ne peut pas mettre à jour un VHU avec plusieurs transporteurs, parce que le backend ne compare pas correctement les valeurs des transporteurs et pense à tort qu'on essaie de les modifier. On avait déjà eu ce bug sur le BSDA.

# Ticket Favro

[BSVHU : Permettre à l'utilisateur de modifier des champs non scellés lorsque cela est possible, même si un des transporteurs visés a procédé à l'enlèvement du déchet](https://favro.com/widget/ab14a4f0460a99a9d64d4945/e907714a4afcdd7815e68432?card=tra-18014)
