### PR TITLE
[TRA-17855] Récupération des metadata du BSDA dans les formulaires front

### DIFF
--- a/front/src/Apps/common/queries/bsda/queries.ts
+++ b/front/src/Apps/common/queries/bsda/queries.ts
@@ -5,6 +5,16 @@ export const GET_BSDA = gql`
   query Bsda($id: ID!) {
     bsda(id: $id) {
       ...FullBsda
+      metadata {
+        errors {
+          message
+          path
+          requiredFor
+        }
+        fields {
+          sealed
+        }
+      }
     }
   }
   ${FullBsdaFragment}


### PR DESCRIPTION
# Contexte

Dans les formulaires front, on ne récupérait pas les metadata, donc on ne disablait pas les champs sealed, par exemple.

# Ticket Favro

[BSDA : Appliquer les règles de gestion des champs scellés en back dans le front](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-17855)
