### PR TITLE
[TRA-18027] ETQ admin je peux anonymiser un utilisateur par son adresse email

### DIFF
--- a/back/src/users/resolvers/mutations/__tests__/anonymizeUser.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/anonymizeUser.integration.ts
@@ -31,8 +31,8 @@ jest.mock("../../../../utils", () => {
 });
 
 const ANONYMIZE_MUTATION = gql`
-  mutation AnonymizeUser($id: ID!) {
-    anonymizeUser(id: $id)
+  mutation AnonymizeUser($idOrEmail: String!) {
+    anonymizeUser(idOrEmail: $idOrEmail)
   }
 `;
 
@@ -46,7 +46,7 @@ describe("disconnectDeletedUser Middleware", () => {
     const user2 = await userFactory();
     const { mutate } = makeClient({ ...user, auth: AuthType.Session });
     const { errors } = await mutate(ANONYMIZE_MUTATION, {
-      variables: { id: user2.id }
+      variables: { idOrEmail: user2.id }
     });
 
     expect(errors.length).toBe(1);
@@ -78,7 +78,7 @@ describe("disconnectDeletedUser Middleware", () => {
     });
 
     const { data } = await mutate(ANONYMIZE_MUTATION, {
-      variables: { id: user.id }
+      variables: { idOrEmail: user.id }
     });
 
     expect(data.anonymizeUser).toContain("-anonymous@trackdechets.fr");
@@ -113,7 +113,7 @@ describe("disconnectDeletedUser Middleware", () => {
     });
 
     const { errors } = await mutate(ANONYMIZE_MUTATION, {
-      variables: { id: user.id }
+      variables: { idOrEmail: user.id }
     });
 
     expect(errors.length).toBe(1);
@@ -139,7 +139,7 @@ describe("disconnectDeletedUser Middleware", () => {
 
     expect(res.body.data.me.email).toEqual(user.email);
     const { data } = await mutate(ANONYMIZE_MUTATION, {
-      variables: { id: user.id }
+      variables: { idOrEmail: user.id }
     });
 
     expect(data.anonymizeUser).toContain("-anonymous@trackdechets.fr");
@@ -152,5 +152,94 @@ describe("disconnectDeletedUser Middleware", () => {
     expect(rejected.body.errors[0]).toMatchObject({
       message: "Vous n'êtes pas connecté."
     });
+  });
+
+  it("should anonymize a user when providing an email and disconnect the session", async () => {
+    const user = await userFactory();
+    const admin = await adminFactory();
+
+    const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
+
+    const { sessionCookie } = await logIn(app, user.email, "pass");
+    const cookieValue = sessionCookie.match(cookieRegExp)![1];
+
+    // should be logged-in
+    const res = await request
+      .post("/")
+      .send({ query: "{ me { email } }" })
+      .set("Cookie", `${sess.name}=${cookieValue}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      me: { email: user.email }
+    });
+
+    const { data } = await mutate(ANONYMIZE_MUTATION, {
+      variables: { idOrEmail: user.email }
+    });
+
+    expect(data.anonymizeUser).toContain("-anonymous@trackdechets.fr");
+
+    // should be logged-out
+    const rejected = await request
+      .post("/")
+      .send({ query: "{ me { email } }" })
+      .set("Cookie", `${sess.name}=${cookieValue}`);
+
+    expect(rejected.status).toBe(302);
+    expect(rejected.headers["location"]).toBe(`${getUIBaseURL()}/login`);
+  });
+
+  it("should return an error for an unknown email", async () => {
+    const admin = await adminFactory();
+
+    const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
+
+    const { errors } = await mutate(ANONYMIZE_MUTATION, {
+      variables: { idOrEmail: "unknown@example.com" }
+    });
+
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toMatchObject({
+      extensions: {
+        code: "BAD_USER_INPUT"
+      }
+    });
+    expect(errors[0].message).toMatch("introuvable");
+  });
+
+  it("should return an error for an empty input", async () => {
+    const admin = await adminFactory();
+
+    const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
+
+    const { errors } = await mutate(ANONYMIZE_MUTATION, {
+      variables: { idOrEmail: "   " }
+    });
+
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toMatchObject({
+      extensions: {
+        code: "BAD_USER_INPUT"
+      }
+    });
+  });
+
+  it("should return an error for an input that is neither an ID nor an email", async () => {
+    const admin = await adminFactory();
+
+    const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
+
+    const { errors } = await mutate(ANONYMIZE_MUTATION, {
+      variables: { idOrEmail: "not-a-valid-id-or-email" }
+    });
+
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toMatchObject({
+      extensions: {
+        code: "BAD_USER_INPUT"
+      }
+    });
+    expect(errors[0].message).toMatch("e-mail non valide");
   });
 });

--- a/back/src/users/resolvers/mutations/anonymizeUser.ts
+++ b/back/src/users/resolvers/mutations/anonymizeUser.ts
@@ -20,10 +20,7 @@ const idOrEmailSchema = z
   .string()
   .transform(v => v.trim())
   .pipe(
-    z.union([
-      z.string().email(),
-      z.string().cuid()
-    ], {
+    z.union([z.string().email(), z.string().cuid()], {
       errorMap: () => ({
         message:
           "Le format de l'identifiant est invalide. Veuillez fournir un identifiant (cuid) ou une adresse email valide."

--- a/back/src/users/resolvers/mutations/anonymizeUser.ts
+++ b/back/src/users/resolvers/mutations/anonymizeUser.ts
@@ -14,20 +14,48 @@ import {
   deleteUserGrants,
   deleteMembershipRequest
 } from "../../database";
+import { z } from "zod";
+
+const idOrEmailSchema = z
+  .string()
+  .transform(v => v.trim())
+  .pipe(
+    z.union([
+      z.string().email(),
+      z.string().cuid()
+    ], {
+      errorMap: () => ({
+        message:
+          "Le format de l'identifiant est invalide. Veuillez fournir un identifiant (cuid) ou une adresse email valide."
+      })
+    })
+  );
 
 /**
- * Soft-delete by anonymizing a User
- * @param userId
+ * Soft-delete by anonymizing a User.
+ * @param idOrEmail - either a database ID (cuid) or an email address
  */
-async function anonymizeUserFn(userId: string): Promise<string> {
-  const user = await prisma.user.findUnique({
-    where: { id: userId }
-  });
+async function anonymizeUserFn(idOrEmail: string): Promise<string> {
+  const result = idOrEmailSchema.safeParse(idOrEmail);
+
+  if (!result.success) {
+    throw new UserInputError(
+      result.error.issues.map(i => i.message).join(", ")
+    );
+  }
+
+  const parsed = result.data;
+  const isEmail = z.string().email().safeParse(parsed).success;
+
+  const user = isEmail
+    ? await prisma.user.findUnique({ where: { email: parsed } })
+    : await prisma.user.findUnique({ where: { id: parsed } });
+
   if (!user) {
-    throw new UserInputError(`Utilisateur ${userId} introuvable`);
+    throw new UserInputError(`Utilisateur ${parsed} introuvable`);
   }
   if (!user.isActive) {
-    throw new UserInputError(`Utilisateur ${userId} déjà inactif`);
+    throw new UserInputError(`Utilisateur ${parsed} déjà inactif`);
   }
   const errors = [
     ...(await checkCompanyAssociations(user)),
@@ -49,7 +77,7 @@ async function anonymizeUserFn(userId: string): Promise<string> {
       await deleteMembershipRequest(user, transaction);
       await prisma.user.update({
         where: {
-          id: userId
+          id: user.id
         },
         data: {
           email: anonEmail,
@@ -70,12 +98,12 @@ async function anonymizeUserFn(userId: string): Promise<string> {
 
 const anonymizeUserResolver: MutationResolvers["anonymizeUser"] = (
   _,
-  { id: userId },
+  { idOrEmail },
   context
 ) => {
   applyAuthStrategies(context, [AuthType.Session]);
   checkIsAdmin(context);
-  return anonymizeUserFn(userId);
+  return anonymizeUserFn(idOrEmail);
 };
 
 export default anonymizeUserResolver;

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -111,8 +111,9 @@ type Mutation {
   """
   USAGE INTERNE
   Tente de désactiver un compte utilisateur (soft-delete et anonymisation)
+  Accepte un identifiant de base de données (ID) ou une adresse email.
   """
-  anonymizeUser(id: ID!): String!
+  anonymizeUser(idOrEmail: String!): String!
 
   """
   USAGE INTERNE

--- a/front/src/admin/user/anonymizeUser.tsx
+++ b/front/src/admin/user/anonymizeUser.tsx
@@ -10,8 +10,8 @@ import Input from "@codegouvfr/react-dsfr/Input";
 import Button from "@codegouvfr/react-dsfr/Button";
 
 const ANONYMIZE_USER = gql`
-  mutation anonymizeUser($id: ID!) {
-    anonymizeUser(id: $id)
+  mutation anonymizeUser($idOrEmail: String!) {
+    anonymizeUser(idOrEmail: $idOrEmail)
   }
 `;
 function AnonymizeUser() {
@@ -24,17 +24,19 @@ function AnonymizeUser() {
     <div>
       <Formik
         initialValues={{
-          id: ""
+          idOrEmail: ""
         }}
         onSubmit={async (values, { resetForm }) => {
           if (
             !window.confirm(
-              `Souhaitez-vous supprimer l'utilisateur ${values.id} ? (action irréversible)`
+              `Souhaitez-vous supprimer l'utilisateur ${values.idOrEmail} ? (action irréversible)`
             )
           ) {
             return;
           }
-          const res = await anonymizeUser({ variables: { id: values.id } });
+          const res = await anonymizeUser({
+            variables: { idOrEmail: values.idOrEmail }
+          });
           resetForm();
           !!res?.data?.anonymizeUser
             ? toast.success(
@@ -52,17 +54,17 @@ function AnonymizeUser() {
         {values => (
           <Form>
             <div className="form__row fr-mt-0 fr-mb-2w">
-              <Field name="id">
+              <Field name="idOrEmail">
                 {({ field }) => {
                   return (
                     <Input
-                      label="Identifiant de base de données du compte à
+                      label="Identifiant ou adresse email du compte à
                           anonymiser et désactiver définitivement"
                       hintText="Attention: action irreversible ! L'utilisateur sera
                             anonymisé et son compte définitivement désactivé."
                       nativeInputProps={{
                         ...field,
-                        placeholder: "userId"
+                        placeholder: "ID ou email"
                       }}
                       className="fr-col-8"
                     />
@@ -70,7 +72,7 @@ function AnonymizeUser() {
                 }}
               </Field>
 
-              <RedErrorMessage name="id" />
+              <RedErrorMessage name="idOrEmail" />
             </div>
             <div className="fr-col-8">
               {error && <DsfrNotificationError apolloError={error} />}
@@ -78,7 +80,7 @@ function AnonymizeUser() {
             <Button
               type="submit"
               priority="primary"
-              disabled={loading || !values?.values?.id}
+              disabled={loading || !values?.values?.idOrEmail}
               className="fr-mt-2w"
             >
               {loading ? "Suppression en cours..." : "Supprimer"}


### PR DESCRIPTION
# Contexte

Demande du support: pouvoir utiliser l'adresse mail plutôt que l'ID pour anonymiser un user.

# Démo

<img width="3198" height="1692" alt="image" src="https://github.com/user-attachments/assets/0fc0befa-4af5-41d7-906b-285150406736" />

# Ticket Favro

[Amélioration panneau d'admin ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/f6d9a4e210fa49bc35c188ed?card=tra-18027)
