### PR TITLE
[HOTFIX] copie la description de consistance en cas de réexpédition

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/createBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/createBsda.integration.ts
@@ -1566,7 +1566,7 @@ describe("Mutation.Bsda.create", () => {
     );
   });
 
-  it("should create a RESHIPMENT bsda and copy consistence from forwarded bsda if field is not provided", async () => {
+  it("should create a RESHIPMENT bsda and copy consistence & consistence description from forwarded bsda if field is not provided", async () => {
     const { company: emitter } = await userWithCompanyFactory("MEMBER");
     const { company: transporter } = await userWithCompanyFactory("MEMBER");
     const { user, company: destination } = await userWithCompanyFactory(
@@ -1581,7 +1581,8 @@ describe("Mutation.Bsda.create", () => {
         destinationCompanySiret: ttr.siret,
         status: BsdaStatus.AWAITING_CHILD,
         destinationOperationCode: "D 15",
-        wasteConsistence: "PULVERULENT"
+        wasteConsistence: "PULVERULENT",
+        wasteConsistenceDescription: "Pulverulent"
       },
       transporterOpt: {
         transporterCompanySiret: transporter.siret
@@ -1655,9 +1656,10 @@ describe("Mutation.Bsda.create", () => {
     expect(reshipped?.type).toEqual("RESHIPMENT");
     expect(reshipped?.forwardingId).toEqual(bsda.id);
     expect(reshipped?.wasteConsistence).toEqual("PULVERULENT"); // consistence matches forwarde bsda consistence
+    expect(reshipped?.wasteConsistenceDescription).toEqual("Pulverulent"); // consistence description matches forwarded bsda consistence description
   });
 
-  it("should create a RESHIPMENT bsda and use provided cosnsitence field ", async () => {
+  it("should create a RESHIPMENT bsda and use provided consistence & consistence description fields ", async () => {
     const worker = await companyFactory();
     const { company: emitter } = await userWithCompanyFactory("MEMBER");
     const { company: transporter } = await userWithCompanyFactory("MEMBER");
@@ -1672,7 +1674,8 @@ describe("Mutation.Bsda.create", () => {
         destinationCompanySiret: ttr.siret,
         status: BsdaStatus.AWAITING_CHILD,
         destinationOperationCode: "D 15",
-        wasteConsistence: "SOLIDE"
+        wasteConsistence: "SOLIDE",
+        wasteConsistenceDescription: "Solide"
       },
       transporterOpt: {
         transporterCompanySiret: transporter.siret
@@ -1707,6 +1710,7 @@ describe("Mutation.Bsda.create", () => {
         adr: "ADR",
         pop: true,
         consistence: "PULVERULENT",
+        consistenceDescription: "Pulverulent",
         familyCode: "Code famille",
         materialName: "A material",
         sealNumbers: ["1", "2"]
@@ -1746,6 +1750,7 @@ describe("Mutation.Bsda.create", () => {
     expect(reshipped?.type).toEqual("RESHIPMENT");
     expect(reshipped?.forwardingId).toEqual(bsda.id);
     expect(reshipped?.wasteConsistence).toEqual("PULVERULENT"); // consistence matches input
+    expect(reshipped?.wasteConsistenceDescription).toEqual("Pulverulent"); // consistence description matches input
   });
 
   it("should create a bsda if destination is NOT verified, provided it's a WASTE_CENTER and bsda is COLLECTION_2710", async () => {

--- a/back/src/bsda/validation/transformers.ts
+++ b/back/src/bsda/validation/transformers.ts
@@ -48,14 +48,25 @@ export const fillWasteConsistenceWhenForwarding: ZodBsdaTransformer =
   async bsda => {
     if (
       bsda.type === "RESHIPMENT" &&
-      !bsda?.wasteConsistence &&
+      (!bsda?.wasteConsistence || !bsda?.wasteConsistenceDescription) &&
       !!bsda?.forwarding
     ) {
       const forwarding = await prisma.bsda.findUnique({
         where: { id: bsda.forwarding }
       });
       if (!!forwarding) {
-        bsda = { ...bsda, wasteConsistence: forwarding.wasteConsistence };
+        if (!bsda?.wasteConsistence) {
+          bsda = {
+            ...bsda,
+            wasteConsistence: forwarding.wasteConsistence
+          };
+        }
+        if (!bsda?.wasteConsistenceDescription) {
+          bsda = {
+            ...bsda,
+            wasteConsistenceDescription: forwarding.wasteConsistenceDescription
+          };
+        }
       }
     }
     return bsda;


### PR DESCRIPTION
# Contexte

La description de la consistance n'était pas copié sur le bordereau de réexpédition, e qui entraînait un blocage à la signature. Cette PR résoud le problème en copiant l'info, en suivant les même règles que pour la consistance (ne remplir automatiquement que si la valeur n'est pas fournie en input).

# Points de vigilance pour les intégrateurs

X

# Démo

https://github.com/user-attachments/assets/b9d8c159-5a9a-4d71-aee0-ae1669e33184

# Ticket Favro

X

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB