### PR TITLE
[HOTFIX] - Import de registre: gestion de cellules typées incorrectement sur XLSX

### DIFF
--- a/libs/back/registry/src/transformers.ts
+++ b/libs/back/registry/src/transformers.ts
@@ -231,7 +231,10 @@ function getCellValue(cell: Excel.Cell) {
     return richTextValue.richText.map(rt => rt.text).join("");
   }
 
-  if (cell.type === Excel.ValueType.Formula) {
+  if (
+    cell.type === Excel.ValueType.Formula ||
+    (cell.type === Excel.ValueType.String && typeof cell.value === "object")
+  ) {
     const formulaValue = cell.value as Excel.CellFormulaValue;
     return formulaValue.result !== undefined ? String(formulaValue.result) : "";
   }


### PR DESCRIPTION
# Contexte

Dans certains cas des cellules contenant du texte étaient détectées par le parser XLSX comme étant du texte, mais leur valeur prenait la forme d'un objet comme pour une formule. J'ajoute donc une gestion de ce cas dans l'extraction des données de cellules.

# Points de vigilance pour les intégrateurs

X

# Démo

X

# Ticket Favro

X

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB