### PR TITLE
fix(BSVHU): TRA-17991: masquer le company selector quand l'installation n'a pas de SIRET

### DIFF
--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
@@ -155,58 +155,60 @@ const EmitterBsvhu = ({ errors }) => {
           disabled={sealedFields.includes(`emitter.irregularSituation`)}
         />
         <h4 className="fr-h4">Entreprise</h4>
-        <CompanySelectorWrapper
-          orgId={siret}
-          favoriteType={FavoriteType.Emitter}
-          disabled={sealedFields.includes(`emitter.company.siret`)}
-          selectedCompanyOrgId={orgId}
-          selectedCompanyError={selectedCompanyError}
-          onCompanySelected={company => {
-            if (company) {
-              let companyData = {
-                orgId: company.orgId,
-                siret: company.siret,
-                vatNumber: company.vatNumber,
-                name: company.name ?? "",
-                address: company.address ?? "",
-                contact: company.contact ?? "",
-                phone: company.contactPhone ?? "",
-                mail: company.contactEmail ?? "",
-                country: company.codePaysEtrangerEtablissement
-              };
-
-              let agrementNumber =
-                company?.vhuAgrementDemolisseur?.agrementNumber ?? "";
-
-              // [tra-13734] don't override field with api data keep the user data value
-              if (company.siret === emitter?.company?.siret) {
-                companyData = {
+        {!emitter.noSiret && (
+          <CompanySelectorWrapper
+            orgId={siret}
+            favoriteType={FavoriteType.Emitter}
+            disabled={sealedFields.includes(`emitter.company.siret`)}
+            selectedCompanyOrgId={orgId}
+            selectedCompanyError={selectedCompanyError}
+            onCompanySelected={company => {
+              if (company) {
+                let companyData = {
                   orgId: company.orgId,
                   siret: company.siret,
                   vatNumber: company.vatNumber,
-                  name: (emitter?.company?.name || company.name) as string,
-                  address: (emitter?.company?.address ||
-                    company.address) as string,
-                  contact: emitter?.company?.contact,
-                  phone: emitter?.company?.phone,
-                  mail: emitter?.company?.mail,
+                  name: company.name ?? "",
+                  address: company.address ?? "",
+                  contact: company.contact ?? "",
+                  phone: company.contactPhone ?? "",
+                  mail: company.contactEmail ?? "",
                   country: company.codePaysEtrangerEtablissement
                 };
 
-                agrementNumber = emitter?.agrementNumber;
-              }
+                let agrementNumber =
+                  company?.vhuAgrementDemolisseur?.agrementNumber ?? "";
 
-              setValue("emitter", {
-                ...emitter,
-                company: {
-                  ...emitter.company,
-                  ...companyData
-                },
-                agrementNumber
-              });
-            }
-          }}
-        />
+                // [tra-13734] don't override field with api data keep the user data value
+                if (company.siret === emitter?.company?.siret) {
+                  companyData = {
+                    orgId: company.orgId,
+                    siret: company.siret,
+                    vatNumber: company.vatNumber,
+                    name: (emitter?.company?.name || company.name) as string,
+                    address: (emitter?.company?.address ||
+                      company.address) as string,
+                    contact: emitter?.company?.contact,
+                    phone: emitter?.company?.phone,
+                    mail: emitter?.company?.mail,
+                    country: company.codePaysEtrangerEtablissement
+                  };
+
+                  agrementNumber = emitter?.agrementNumber;
+                }
+
+                setValue("emitter", {
+                  ...emitter,
+                  company: {
+                    ...emitter.company,
+                    ...companyData
+                  },
+                  agrementNumber
+                });
+              }
+            }}
+          />
+        )}
         {!emitter?.company?.siret &&
           formState.errors?.emitter?.["company"]?.siret && (
             <p className="fr-text--sm fr-error-text fr-mb-4v">


### PR DESCRIPTION
# Contexte

Lorsque je coche la case "L'installation n'a pas de SIRET", le company selector devrait disparaître, afin de ne pas permettre à l'utilisateur d'ajouter un établissement s'il a sélectionné la case


# Démo

<img width="1072" height="817" alt="image" src="https://github.com/user-attachments/assets/4ffdf724-8d62-41c1-817c-13fcc2b10800" />
<img width="1051" height="790" alt="image" src="https://github.com/user-attachments/assets/e8ae8e8c-1b56-4795-82bf-68d8714a55d0" />


# Ticket Favro

[Lorsque la case L'installation n'a pas de SIRET est cochée, il faut retirer le company selector](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-17991)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB