### PR TITLE
TRA-17890-Résoudre-bug-affichage-mention-estimé-uniquement-si-la-case…

### DIFF
--- a/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
+++ b/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
@@ -205,16 +205,21 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               checked={bsdasri?.emitter?.emission?.weight?.isEstimate === false}
               readOnly
             />{" "}
-            réelle
+            Réelle
             <br />
             <input
               type="checkbox"
               checked={bsdasri?.emitter?.emission?.weight?.isEstimate === true}
               readOnly
             />{" "}
-            Estimée
-            <br />
-            "QUANTITÉ ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
+            <span style={{ whiteSpace: "nowrap" }}>
+              Estimée{" "}
+              {bsdasri?.emitter?.emission?.weight?.isEstimate ? (
+                <>("Quantité estimée conformément au 5.4.1.1.3.2" de l'ADR)</>
+              ) : (
+                ""
+              )}
+            </span>
           </div>
         </div>
         {/* End PRED */}
@@ -341,7 +346,7 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               }
               readOnly
             />{" "}
-            réelle <span> - </span>
+            Réelle <span> - </span>
             <input
               type="checkbox"
               checked={
@@ -349,9 +354,14 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               }
               readOnly
             />{" "}
-            Estimée
-            <br />
-            "QUANTITÉ ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
+            <span style={{ whiteSpace: "nowrap" }}>
+              Estimée{" "}
+              {bsdasri?.transporter?.transport?.weight?.isEstimate ? (
+                <>("Quantité estimée conformément au 5.4.1.1.3.2" de l'ADR)</>
+              ) : (
+                ""
+              )}
+            </span>
           </div>
         </div>
         {/* End Transporter */}


### PR DESCRIPTION
# Contexte

Correction du rendu PDF BSDASRI pour afficher la mention liée à la quantité estimée uniquement lorsque la case Estimée est cochée.

# Démo

<img width="623" height="536" alt="image" src="https://github.com/user-attachments/assets/ad65d383-6281-4c85-a205-2eb9746eccc4" />
<img width="625" height="524" alt="image" src="https://github.com/user-attachments/assets/bc3c3965-1720-4d05-b28f-eb41ab502e13" />

# Ticket Favro

[BSDASRI : Afficher la mention "quantité estimée conformément au 5.4.1.1.3.2" uniquement si la case "Ce poids est estimé" a été coché ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37d90d5b2a9943fba9e69c56?card=tra-17890)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB