### PR TITLE
hotfix:tra-18105:  Régression : impossible d’ajouter/modifier une installation d’entreposage provisoire (TTR) après signature de l’entreprise de travaux et avant signature du transporteur

### DIFF
--- a/back/src/bsda/resolvers/BsdaMetadata.ts
+++ b/back/src/bsda/resolvers/BsdaMetadata.ts
@@ -65,7 +65,8 @@ export const Metadata: BsdaMetadataResolvers = {
     return getRequiredAndSealedFieldPaths(
       zodBsda,
       currentSignatureAncestors,
-      context.user ?? undefined
+      context.user ?? undefined,
+      true
     );
   },
   latestRevision: async (metadata: BsdaMetadata & { id: string }) => {

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -65,6 +65,10 @@ type RuleContext<T extends ZodBsda | ZodBsdaTransporter> = {
   // Liste des "rôles" que l'utilisateur a sur le BSDA (ex: émetteur, transporteur, etc).
   // Permet de conditionner un check a un rôle. Ex: "Ce champ est modifiable mais uniquement par l'émetteur"
   userFunctions: BsdaUserFunctions;
+  // Rendre la fonction qui utilise ce context plus
+  // tolérente pour que les champs TTR ne soit plus
+  // grisés en mode lecture seulement
+  isReadOnly?: boolean;
 };
 
 // Fonction permettant de définir une signature de champ requis ou
@@ -165,7 +169,9 @@ const sealedFromEmissionExceptAddOrRemoveNextDestination: GetBsdaSignatureTypeFn
   // then I can either add or remove a nextDestination. To do so I need to edit the destination.
   if (
     (isEmitter || isWorker || isTransporter || isDestination) &&
-    (isAddingNextDestination || isRemovingNextDestination)
+    (isAddingNextDestination ||
+      isRemovingNextDestination ||
+      context?.isReadOnly)
   ) {
     return "TRANSPORT";
   }
@@ -997,7 +1003,8 @@ export const bsdaEditionRules: BsdaEditionRules = {
 export const getRequiredAndSealedFieldPaths = async (
   bsda: ZodBsda,
   currentSignatures: AllBsdaSignatureType[],
-  user: User | undefined
+  user: User | undefined,
+  isReadOnly?: boolean //optional
 ): Promise<{
   sealed: EditionRulePath[];
 }> => {
@@ -1009,7 +1016,8 @@ export const getRequiredAndSealedFieldPaths = async (
     if (path && sealed) {
       const isSealed = isBsdaFieldSealed(sealed, bsda, currentSignatures, {
         persisted: bsda,
-        userFunctions
+        userFunctions,
+        isReadOnly
       });
       if (isSealed) {
         sealedFields.push(path);

--- a/front/src/Apps/Dashboard/Creation/bsda/steps/Destination.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsda/steps/Destination.tsx
@@ -465,13 +465,13 @@ const DestinationBsda = () => {
                       "Je souhaite ajouter une installation intermédiaire de transit ou de groupement d'amiante",
                     nativeInputProps: {
                       onChange: onNextDestinationToggle,
-                      checked: hasNextDestination
+                      checked: hasNextDestination,
+                      disabled: sealedFields.includes(
+                        `destination.company.siret`
+                      )
                     }
                   }
                 ]}
-                disabled={sealedFields.includes(
-                  `destination.operation.nextDestination`
-                )}
               />
             </div>
 


### PR DESCRIPTION

# Contexte

 Il doit etre toujours possible d’ajouter ou d’enlever l’entreposage provisoire après signature de l’entreprise de travaux et avant signature d transporteur.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo


https://github.com/user-attachments/assets/0db1767e-1a80-4eba-8d57-30fb3db18651


# Ticket Favro

[BSDA : Régression : impossible d’ajouter/modifier une installation d’entreposage provisoire (TTR) après signature de l’entreprise de travaux et avant signature du transporteur](https://favro.com/organization/ab14a4f0460a99a9d64d4945/794c4eb43db3ac5bbeef7d76?card=tra-18105)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB