### PR TITLE
[TRA-17921]-feat: Activer la double authentification

### DIFF
--- a/back/src/common/typeDefs/common.objects.graphql
+++ b/back/src/common/typeDefs/common.objects.graphql
@@ -46,4 +46,7 @@ type User {
   trackingConsent: Boolean!
 
   trackingConsentUntil: DateTime
+
+  "Indique si l'authentification TOTP est activée sur le compte"
+  totpEnabled: Boolean!
 }

--- a/back/src/users/resolvers/Mutation.ts
+++ b/back/src/users/resolvers/Mutation.ts
@@ -1,6 +1,9 @@
 import type { MutationResolvers } from "@td/codegen-back";
 import signup from "./mutations/signup";
 import changePassword from "./mutations/changePassword";
+import generateTotpSetup from "./mutations/generateTotpSetup";
+import confirmTotpSetup from "./mutations/confirmTotpSetup";
+import disableTotp from "./mutations/disableTotp";
 import createPasswordResetRequest from "./mutations/createPasswordResetRequest";
 import resendActivationEmail from "./mutations/resendActivationEmail";
 import editProfile from "./mutations/editProfile";
@@ -44,7 +47,10 @@ const Mutation: MutationResolvers = {
   revokeAllAccessTokens,
   changeUserRole,
   subscribeToCompanyNotifications,
-  subscribeToNotifications
+  subscribeToNotifications,
+  generateTotpSetup,
+  confirmTotpSetup,
+  disableTotp
 };
 
 export default Mutation;

--- a/back/src/users/resolvers/Mutation.ts
+++ b/back/src/users/resolvers/Mutation.ts
@@ -3,7 +3,6 @@ import signup from "./mutations/signup";
 import changePassword from "./mutations/changePassword";
 import generateTotpSetup from "./mutations/generateTotpSetup";
 import confirmTotpSetup from "./mutations/confirmTotpSetup";
-import disableTotp from "./mutations/disableTotp";
 import createPasswordResetRequest from "./mutations/createPasswordResetRequest";
 import resendActivationEmail from "./mutations/resendActivationEmail";
 import editProfile from "./mutations/editProfile";
@@ -49,8 +48,7 @@ const Mutation: MutationResolvers = {
   subscribeToCompanyNotifications,
   subscribeToNotifications,
   generateTotpSetup,
-  confirmTotpSetup,
-  disableTotp
+  confirmTotpSetup
 };
 
 export default Mutation;

--- a/back/src/users/resolvers/User.ts
+++ b/back/src/users/resolvers/User.ts
@@ -4,6 +4,15 @@ import { prisma } from "@td/prisma";
 import { toGqlCompanyPrivate } from "../../companies/converters";
 
 const userResolvers: UserResolvers = {
+  // Indique si le TOTP est activé sur le compte
+  totpEnabled: parent => {
+    const p = parent as {
+      totpActivatedAt?: Date | null;
+      totpSeed?: string | null;
+    };
+    return !!p.totpActivatedAt && !!p.totpSeed;
+  },
+
   // Returns the list of companies a user belongs to
   // Information from TD and s3ic are merged in a separate resolver (CompanyPrivate.installation)
   // to make up an instance of CompanyPrivate

--- a/back/src/users/resolvers/mutations/__tests__/changePassword.test.ts
+++ b/back/src/users/resolvers/mutations/__tests__/changePassword.test.ts
@@ -45,6 +45,12 @@ describe("changePassword", () => {
     userMock.mockResolvedValueOnce({
       password: hashedPassword
     });
+    updateUserMock.mockResolvedValueOnce({
+      id: "userId",
+      totpSeed: null,
+      activatedAt: null
+    });
+
     await changePassword("userId", {
       oldPassword: "oldPassword",
       newPassword: "Trackdechets1#"

--- a/back/src/users/resolvers/mutations/__tests__/editProfile.test.ts
+++ b/back/src/users/resolvers/mutations/__tests__/editProfile.test.ts
@@ -19,6 +19,11 @@ describe("editProfile", () => {
 
   it("should allow setting fields", async () => {
     await editProfile("userId", { name: "John Doe" });
+    mockUpdateUser.mockResolvedValueOnce({
+      id: "userId",
+      totpSeed: null,
+      activatedAt: null
+    });
     expect(mockUpdateUser).toHaveBeenCalledWith({
       where: { id: "userId" },
       data: { name: "John Doe" }

--- a/back/src/users/resolvers/mutations/changePassword.ts
+++ b/back/src/users/resolvers/mutations/changePassword.ts
@@ -47,7 +47,7 @@ export async function changePasswordFn(
     // companies are resolved through a separate resolver (User.companies)
     companies: [],
     featureFlags: [],
-    totpEnabled: !!updatedUser.totpSeed && !!updatedUser.activatedAt
+    totpEnabled: !!updatedUser?.totpSeed && !!updatedUser?.activatedAt
   };
 }
 

--- a/back/src/users/resolvers/mutations/changePassword.ts
+++ b/back/src/users/resolvers/mutations/changePassword.ts
@@ -46,7 +46,8 @@ export async function changePasswordFn(
     ...updatedUser,
     // companies are resolved through a separate resolver (User.companies)
     companies: [],
-    featureFlags: []
+    featureFlags: [],
+    totpEnabled: !!updatedUser.totpSeed && !!updatedUser.activatedAt
   };
 }
 

--- a/back/src/users/resolvers/mutations/confirmTotpSetup.ts
+++ b/back/src/users/resolvers/mutations/confirmTotpSetup.ts
@@ -1,0 +1,119 @@
+import { randomBytes } from "crypto";
+import { hash } from "bcrypt";
+import { TOTP } from "totp-generator";
+import { prisma } from "@td/prisma";
+import { applyAuthStrategies, AuthType } from "../../../auth/auth";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import type { MutationResolvers } from "@td/codegen-back";
+import { UserInputError } from "../../../common/errors";
+import { sendMail } from "../../../mailer/mailing";
+import { onTotpActivated, renderMail } from "@td/mail";
+
+const RECOVERY_CODE_COUNT = 10;
+const RECOVERY_CODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const BCRYPT_SALT_ROUNDS = 10;
+
+/**
+ * Génère un code de récupération aléatoire au format XXXXX-XXXXX.
+ * La saisie est insensible à la casse et le tiret est ignoré à la validation.
+ */
+function generateRecoveryCode(): string {
+  const bytes = randomBytes(10);
+  const raw = Array.from(bytes)
+    .map(b => RECOVERY_CODE_CHARS[b % RECOVERY_CODE_CHARS.length])
+    .join("");
+  return `${raw.slice(0, 5)}-${raw.slice(5, 10)}`;
+}
+
+/**
+ * Vérifie un code TOTP avec une tolérance de 30 secondes.
+ */
+function verifyTotpCode(seed: string, code: string): boolean {
+  const { otp } = TOTP.generate(seed);
+  const thirtySecondsAgo = Date.now() - 30 * 1000;
+  const { otp: lastOtp } = TOTP.generate(seed, { timestamp: thirtySecondsAgo });
+  return [otp, lastOtp].includes(code);
+}
+
+/**
+ * Confirme la configuration TOTP en validant le premier code.
+ * Active le TOTP, génère les codes de récupération et envoie un e-mail de confirmation.
+ * Révoque les sessions actives sur les autres appareils via passwordUpdatedAt.
+ */
+const confirmTotpSetupResolver: MutationResolvers["confirmTotpSetup"] = async (
+  _,
+  { code },
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  const user = checkIsAuthenticated(context);
+
+  const dbUser = await prisma.user.findUniqueOrThrow({
+    where: { id: user.id }
+  });
+
+  if (!dbUser.totpSeed) {
+    throw new UserInputError(
+      "Aucun secret TOTP en cours de configuration. Veuillez relancer la procédure."
+    );
+  }
+
+  if (dbUser.totpActivatedAt) {
+    throw new UserInputError("Le TOTP est déjà activé sur ce compte.");
+  }
+
+  if (!verifyTotpCode(dbUser.totpSeed, code)) {
+    throw new UserInputError(
+      "Le code est invalide. Vérifiez votre application d'authentification et réessayez."
+    );
+  }
+
+  // Génération des codes de récupération
+  const plainCodes = Array.from(
+    { length: RECOVERY_CODE_COUNT },
+    generateRecoveryCode
+  );
+
+  // Normalisation avant hachage : casse insensible, tiret ignoré
+  const hashedCodes = await Promise.all(
+    plainCodes.map(c =>
+      hash(c.replace(/-/g, "").toUpperCase(), BCRYPT_SALT_ROUNDS)
+    )
+  );
+
+  const now = new Date();
+
+  await prisma.$transaction([
+    // Activation du TOTP
+    prisma.user.update({
+      where: { id: dbUser.id },
+      data: {
+        totpActivatedAt: now,
+        // Mise à jour de passwordUpdatedAt pour invalider les sessions des autres appareils
+        passwordUpdatedAt: now
+      }
+    }),
+    // Suppression de tout code de récupération existant
+    prisma.totpRecoveryCode.deleteMany({ where: { userId: dbUser.id } }),
+    // Stockage des codes hachés
+    ...hashedCodes.map(codeHash =>
+      prisma.totpRecoveryCode.create({
+        data: { userId: dbUser.id, codeHash }
+      })
+    )
+  ]);
+
+  // Mise à jour de issuedAt pour garder la session courante valide
+  context.req.session.issuedAt = new Date().toISOString();
+
+  // E-mail de confirmation
+  await sendMail(
+    renderMail(onTotpActivated, {
+      to: [{ name: dbUser.name, email: dbUser.email }]
+    })
+  );
+
+  return { codes: plainCodes };
+};
+
+export default confirmTotpSetupResolver;

--- a/back/src/users/resolvers/mutations/confirmTotpSetup.ts
+++ b/back/src/users/resolvers/mutations/confirmTotpSetup.ts
@@ -18,10 +18,24 @@ const BCRYPT_SALT_ROUNDS = 10;
  * La saisie est insensible à la casse et le tiret est ignoré à la validation.
  */
 function generateRecoveryCode(): string {
-  const bytes = randomBytes(10);
-  const raw = Array.from(bytes)
-    .map(b => RECOVERY_CODE_CHARS[b % RECOVERY_CODE_CHARS.length])
-    .join("");
+  const charsetLength = RECOVERY_CODE_CHARS.length;
+  const maxUnbiased = Math.floor(256 / charsetLength) * charsetLength;
+  const chars: string[] = [];
+
+  while (chars.length < 10) {
+    const bytes = randomBytes(10 - chars.length);
+    for (const b of bytes) {
+      if (b >= maxUnbiased) {
+        continue;
+      }
+      chars.push(RECOVERY_CODE_CHARS[b % charsetLength]);
+      if (chars.length === 10) {
+        break;
+      }
+    }
+  }
+
+  const raw = chars.join("");
   return `${raw.slice(0, 5)}-${raw.slice(5, 10)}`;
 }
 

--- a/back/src/users/resolvers/mutations/editProfile.ts
+++ b/back/src/users/resolvers/mutations/editProfile.ts
@@ -63,7 +63,8 @@ export async function editProfileFn(
     ...updatedUser,
     // companies are resolved through a separate resolver (User.companies)
     companies: [],
-    featureFlags: []
+    featureFlags: [],
+    totpEnabled: !!updatedUser.totpSeed && !!updatedUser.activatedAt
   };
 }
 

--- a/back/src/users/resolvers/mutations/editProfile.ts
+++ b/back/src/users/resolvers/mutations/editProfile.ts
@@ -64,7 +64,7 @@ export async function editProfileFn(
     // companies are resolved through a separate resolver (User.companies)
     companies: [],
     featureFlags: [],
-    totpEnabled: !!updatedUser.totpSeed && !!updatedUser.activatedAt
+    totpEnabled: !!updatedUser?.totpSeed && !!updatedUser?.activatedAt
   };
 }
 

--- a/back/src/users/resolvers/mutations/generateTotpSetup.ts
+++ b/back/src/users/resolvers/mutations/generateTotpSetup.ts
@@ -1,0 +1,61 @@
+import { randomBytes } from "crypto";
+import { prisma } from "@td/prisma";
+import { applyAuthStrategies, AuthType } from "../../../auth/auth";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import type { MutationResolvers } from "@td/codegen-back";
+
+const BASE32_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/**
+ * Génère un secret TOTP aléatoire encodé en base32 (20 octets = 160 bits).
+ */
+function generateBase32Secret(byteLength = 20): string {
+  const bytes = randomBytes(byteLength);
+  let result = "";
+  let bits = 0;
+  let value = 0;
+
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      result += BASE32_CHARS[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+
+  if (bits > 0) {
+    result += BASE32_CHARS[(value << (5 - bits)) & 31];
+  }
+
+  return result;
+}
+
+/**
+ * Initie la configuration TOTP pour l'utilisateur connecté.
+ * Génère un nouveau secret, le stocke temporairement (non activé)
+ * et retourne le secret en clair et l'URL otpauth pour affichage en QR code.
+ */
+const generateTotpSetupResolver: MutationResolvers["generateTotpSetup"] =
+  async (_, __, context) => {
+    applyAuthStrategies(context, [AuthType.Session]);
+    const user = checkIsAuthenticated(context);
+
+    const secret = generateBase32Secret();
+
+    const issuer = "Trackdéchets";
+    const label = encodeURIComponent(`${issuer}:${user.email}`);
+    const qrCodeUrl = `otpauth://totp/${label}?secret=${secret}&issuer=${encodeURIComponent(
+      issuer
+    )}&algorithm=SHA1&digits=6&period=30`;
+
+    // Stocker le secret en attente de validation (totpActivatedAt reste null)
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { totpSeed: secret }
+    });
+
+    return { secret, qrCodeUrl };
+  };
+
+export default generateTotpSetupResolver;

--- a/back/src/users/resolvers/mutations/joinWithInvite.ts
+++ b/back/src/users/resolvers/mutations/joinWithInvite.ts
@@ -77,7 +77,8 @@ const joinWithInviteResolver: MutationResolvers["joinWithInvite"] = async (
     ...user,
     // companies are resolved through a separate resolver (User.companies)
     companies: [],
-    featureFlags: []
+    featureFlags: [],
+    totpEnabled: !!user.totpSeed && !!user.activatedAt
   };
 };
 

--- a/back/src/users/resolvers/queries/me.ts
+++ b/back/src/users/resolvers/queries/me.ts
@@ -10,7 +10,7 @@ const meResolver: QueryResolvers["me"] = async (parent, args, context) => {
     isAdmin: user.isAdmin && !!user.totpActivatedAt && !!user.totpSeed,
     companies: [],
     featureFlags: [],
-    totpEnabled: !!user.totpSeed && !!user.activatedAt
+    totpEnabled: !!user?.totpSeed && !!user?.activatedAt
   };
 };
 

--- a/back/src/users/resolvers/queries/me.ts
+++ b/back/src/users/resolvers/queries/me.ts
@@ -9,7 +9,8 @@ const meResolver: QueryResolvers["me"] = async (parent, args, context) => {
     // companies are resolved through a separate resolver (User.companies)
     isAdmin: user.isAdmin && !!user.totpActivatedAt && !!user.totpSeed,
     companies: [],
-    featureFlags: []
+    featureFlags: [],
+    totpEnabled: !!user.totpSeed && !!user.activatedAt
   };
 };
 

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -138,4 +138,26 @@ type Mutation {
   subscribeToNotifications(
     input: SubscribeToNotificationsInput!
   ): [CompanyPrivate!]!
+
+  """
+  USAGE INTERNE
+  Initie la configuration TOTP : génère un secret et retourne l'URL otpauth
+  pour affichage en QR code. Le secret est stocké temporairement (non activé).
+  """
+  generateTotpSetup: TotpSetup!
+
+  """
+  USAGE INTERNE
+  Confirme la configuration TOTP en validant le premier code généré par
+  l'application d'authentification. Active le TOTP et retourne les codes
+  de récupération à usage unique (affichage unique).
+  """
+  confirmTotpSetup(code: String!): TotpRecoveryCodes!
+
+  """
+  USAGE INTERNE
+  Désactive le TOTP sur le compte de l'utilisateur connecté.
+  Nécessite un code TOTP valide pour confirmer l'action.
+  """
+  disableTotp(code: String!): User!
 }

--- a/back/src/users/typeDefs/private/user.objects.graphql
+++ b/back/src/users/typeDefs/private/user.objects.graphql
@@ -84,6 +84,26 @@ type MembershipRequestForAdmin {
   createdAt: DateTime!
 }
 
+"""
+Résultat de l'initialisation de la configuration TOTP.
+Contient le secret en clair (pour saisie manuelle) et l'URL du QR code.
+"""
+type TotpSetup {
+  "Secret TOTP à saisir manuellement si le scan du QR code n'est pas possible"
+  secret: String!
+  "URL otpauth à encoder en QR code côté client"
+  qrCodeUrl: String!
+}
+
+"""
+Codes de récupération TOTP à usage unique.
+Affichés une seule fois lors de l'activation.
+"""
+type TotpRecoveryCodes {
+  "Liste des codes de récupération en clair (affichage unique)"
+  codes: [String!]!
+}
+
 type MembershipRequestEdge {
   cursor: String!
   node: MembershipRequestForAdmin!

--- a/front/src/Apps/Account/Account.tsx
+++ b/front/src/Apps/Account/Account.tsx
@@ -15,11 +15,13 @@ import "../Dashboard/dashboard.scss";
 import { useMedia } from "../../common/use-media";
 import { MEDIA_QUERIES } from "../../common/config";
 import AccountNotifications from "./AccountNotifications/AccountNotifications";
+import AccountAuthentication from "./AccountAuthentication/AccountAuthentication";
 
 export const GET_ME = gql`
   {
     me {
       ...AccountInfoFragment
+      totpEnabled
     }
   }
   ${AccountInfo.fragments.me}
@@ -69,6 +71,15 @@ export default function Account() {
               element={
                 <AccountContentWrapper title="Applications et API">
                   <AccountApplications />
+                </AccountContentWrapper>
+              }
+            />
+
+            <Route
+              path={toRelative(routes.account.authentication)}
+              element={
+                <AccountContentWrapper title="Authentification">
+                  <AccountAuthentication totpEnabled={data.me.totpEnabled} />
                 </AccountContentWrapper>
               }
             />

--- a/front/src/Apps/Account/AccountAuthentication/AccountAuthentication.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/AccountAuthentication.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from "react";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import TotpSetupWizard from "./TotpSetupWizard";
+import TotpDisableModal from "./TotpDisableModal";
+import { useApolloClient } from "@apollo/client";
+import { GET_ME } from "../Account";
+
+// Cadenas fermé — fill blanc (#F5F5FE) : visible sur le bouton primary (fond bleu)
+const LockClosedIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+    style={{ marginLeft: "0.5rem", flexShrink: 0 }}
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M19 10H20C20.5523 10 21 10.4477 21 11V21C21 21.5523 20.5523 22 20 22H4C3.44772 22 3 21.5523 3 21V11C3 10.4477 3.44772 10 4 10H5V9C5 6.49914 6.33419 4.18825 8.5 2.93782C10.6658 1.68739 13.3342 1.68739 15.5 2.93782C17.6658 4.18825 19 6.49914 19 9V10ZM5 12V20H19V12H5ZM11 14H13V18H11V14ZM17 10V9C17 6.23858 14.7614 4 12 4C9.23858 4 7 6.23858 7 9V10H17Z"
+      fill="#F5F5FE"
+    />
+  </svg>
+);
+
+// Cadenas ouvert — fill bleu DSFR (#000091) : visible sur le bouton secondary (fond blanc)
+const LockOpenIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+    style={{ marginLeft: "0.5rem", flexShrink: 0 }}
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M18.262 5.86904L16.473 6.76304C15.4364 4.68779 13.1085 3.59808 10.8509 4.13121C8.59323 4.66435 6.99876 6.68029 7 9.00004V10H20C20.5523 10 21 10.4478 21 11V21C21 21.5523 20.5523 22 20 22H4C3.44772 22 3 21.5523 3 21V11C3 10.4478 3.44772 10 4 10H5V9.00004C4.99883 5.7527 7.23115 2.93094 10.3916 2.1848C13.5521 1.43865 16.8107 2.96406 18.262 5.86904ZM19 12H5V20H19V12ZM14 15V17H10V15H14Z"
+      fill="#000091"
+    />
+  </svg>
+);
+
+type Props = {
+  totpEnabled: boolean;
+};
+
+export default function AccountAuthentication({ totpEnabled }: Props) {
+  const [showSetupWizard, setShowSetupWizard] = useState(false);
+  const [showDisableModal, setShowDisableModal] = useState(false);
+  const client = useApolloClient();
+
+  const handleSetupSuccess = () => {
+    setShowSetupWizard(false);
+    client.refetchQueries({ include: [GET_ME] });
+  };
+
+  const handleDisableSuccess = () => {
+    setShowDisableModal(false);
+    client.refetchQueries({ include: [GET_ME] });
+  };
+
+  return (
+    <div>
+      <h3 className="fr-h3">Authentification à deux facteurs (TOTP)</h3>
+
+      {totpEnabled ? (
+        <>
+          <p className="fr-text--bold fr-mb-3w">
+            L'authentification TOTP est activée sur votre compte
+          </p>
+          {/* Bouton secondary (fond blanc) : icône cadenas ouvert bleu foncé */}
+          <Button
+            priority="secondary"
+            onClick={() => setShowDisableModal(true)}
+          >
+            Désactiver l'authentification TOTP
+            <LockOpenIcon />
+          </Button>
+        </>
+      ) : (
+        <>
+          <p className="fr-text--bold fr-mb-3w">
+            L'authentification TOTP n'est pas activée sur votre compte
+          </p>
+          {/* Bouton primary (fond bleu) : icône cadenas fermé blanc */}
+          <Button onClick={() => setShowSetupWizard(true)} className="fr-mb-3w">
+            Activer l'authentification TOTP
+            <LockClosedIcon />
+          </Button>
+          <p className="fr-text--bold fr-mb-1w">
+            Sécurisez votre compte avec la double authentification !
+          </p>
+          <p className="fr-mb-1w">
+            Protégez votre compte est primordial, et la sécurité apportée par un
+            simple mot de passe n'est pas toujours suffisante.
+          </p>
+          <p className="fr-mb-1w">
+            En activant la double authentification, vous augmentez votre niveau
+            de sécurité : votre mot de passe seul ne suffira plus à compromettre
+            votre compte, il faudra en plus être en possession de votre
+            téléphone ou de votre clé de sécurité.
+          </p>
+          <a
+            href="https://faq.trackdechets.fr"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="fr-link"
+          >
+            En savoir plus
+          </a>
+        </>
+      )}
+
+      {showSetupWizard && (
+        <TotpSetupWizard
+          onSuccess={handleSetupSuccess}
+          onClose={() => setShowSetupWizard(false)}
+        />
+      )}
+
+      {showDisableModal && (
+        <TotpDisableModal
+          onSuccess={handleDisableSuccess}
+          onClose={() => setShowDisableModal(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/front/src/Apps/Account/AccountAuthentication/AccountAuthentication.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/AccountAuthentication.tsx
@@ -57,8 +57,6 @@ export default function AccountAuthentication({ totpEnabled }: Props) {
 
   return (
     <div>
-      <h3 className="fr-h3">Authentification à deux facteurs (TOTP)</h3>
-
       {totpEnabled ? (
         <>
           <p className="fr-text--bold fr-mb-3w">
@@ -80,14 +78,14 @@ export default function AccountAuthentication({ totpEnabled }: Props) {
             Activer l'authentification TOTP
             <LockClosedIcon />
           </Button>
-          <p className="fr-text--bold fr-mb-1w">
+          <p className="fr-mb-3w">
             Sécurisez votre compte avec la double authentification !
           </p>
-          <p className="fr-mb-1w">
+          <p className="fr-mb-3w">
             Protégez votre compte est primordial, et la sécurité apportée par un
             simple mot de passe n'est pas toujours suffisante.
           </p>
-          <p className="fr-mb-1w">
+          <p className="fr-mb-3w">
             En activant la double authentification, vous augmentez votre niveau
             de sécurité : votre mot de passe seul ne suffira plus à compromettre
             votre compte, il faudra en plus être en possession de votre

--- a/front/src/Apps/Account/AccountAuthentication/AccountAuthentication.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/AccountAuthentication.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from "react";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import TotpSetupWizard from "./TotpSetupWizard";
-import TotpDisableModal from "./TotpDisableModal";
 import { useApolloClient } from "@apollo/client";
 import { GET_ME } from "../Account";
 
-// Cadenas fermé — fill blanc (#F5F5FE) : visible sur le bouton primary (fond bleu)
 const LockClosedIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -25,7 +23,6 @@ const LockClosedIcon = () => (
   </svg>
 );
 
-// Cadenas ouvert — fill bleu DSFR (#000091) : visible sur le bouton secondary (fond blanc)
 const LockOpenIcon = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -51,16 +48,10 @@ type Props = {
 
 export default function AccountAuthentication({ totpEnabled }: Props) {
   const [showSetupWizard, setShowSetupWizard] = useState(false);
-  const [showDisableModal, setShowDisableModal] = useState(false);
   const client = useApolloClient();
 
   const handleSetupSuccess = () => {
     setShowSetupWizard(false);
-    client.refetchQueries({ include: [GET_ME] });
-  };
-
-  const handleDisableSuccess = () => {
-    setShowDisableModal(false);
     client.refetchQueries({ include: [GET_ME] });
   };
 
@@ -73,11 +64,8 @@ export default function AccountAuthentication({ totpEnabled }: Props) {
           <p className="fr-text--bold fr-mb-3w">
             L'authentification TOTP est activée sur votre compte
           </p>
-          {/* Bouton secondary (fond blanc) : icône cadenas ouvert bleu foncé */}
-          <Button
-            priority="secondary"
-            onClick={() => setShowDisableModal(true)}
-          >
+
+          <Button priority="secondary">
             Désactiver l'authentification TOTP
             <LockOpenIcon />
           </Button>
@@ -87,7 +75,7 @@ export default function AccountAuthentication({ totpEnabled }: Props) {
           <p className="fr-text--bold fr-mb-3w">
             L'authentification TOTP n'est pas activée sur votre compte
           </p>
-          {/* Bouton primary (fond bleu) : icône cadenas fermé blanc */}
+
           <Button onClick={() => setShowSetupWizard(true)} className="fr-mb-3w">
             Activer l'authentification TOTP
             <LockClosedIcon />
@@ -120,13 +108,6 @@ export default function AccountAuthentication({ totpEnabled }: Props) {
         <TotpSetupWizard
           onSuccess={handleSetupSuccess}
           onClose={() => setShowSetupWizard(false)}
-        />
-      )}
-
-      {showDisableModal && (
-        <TotpDisableModal
-          onSuccess={handleDisableSuccess}
-          onClose={() => setShowDisableModal(false)}
         />
       )}
     </div>

--- a/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
@@ -1,0 +1,411 @@
+import React, { useState } from "react";
+import { gql, useMutation } from "@apollo/client";
+import QRCode from "react-qr-code";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import TdModal from "../../common/Components/Modal/Modal";
+import { DsfrNotificationError } from "../../common/Components/Error/Error";
+
+const GENERATE_TOTP_SETUP = gql`
+  mutation GenerateTotpSetup {
+    generateTotpSetup {
+      secret
+      qrCodeUrl
+    }
+  }
+`;
+
+const CONFIRM_TOTP_SETUP = gql`
+  mutation ConfirmTotpSetup($code: String!) {
+    confirmTotpSetup(code: $code) {
+      codes
+    }
+  }
+`;
+
+// 4 étapes : QR code et validation sont fusionnés dans une même étape
+type Step = "explanation" | "qrcode" | "recovery" | "success";
+
+type Props = {
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+const STEP_LABELS: Record<Step, string> = {
+  explanation: "Explication",
+  qrcode: "QRcode",
+  recovery: "Clé de récupération",
+  success: "Confirmation"
+};
+
+// Label affiché dans le stepper pour indiquer l'étape suivante
+const NEXT_STEP_LABELS: Partial<Record<Step, string>> = {
+  explanation: "QRcode",
+  qrcode: "Clé de récupération",
+  recovery: "Confirmation"
+};
+
+const STEPS: Step[] = ["explanation", "qrcode", "recovery", "success"];
+
+export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
+  const [step, setStep] = useState<Step>("explanation");
+
+  // Étape 1
+  const [appInstalled, setAppInstalled] = useState(false);
+  const [showAppError, setShowAppError] = useState(false);
+
+  // Étape 2
+  const [secret, setSecret] = useState<string | null>(null);
+  const [qrCodeUrl, setQrCodeUrl] = useState<string | null>(null);
+  const [totpCode, setTotpCode] = useState("");
+  const [showManualKey, setShowManualKey] = useState(false);
+
+  // Étape 3
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [savedConfirmed, setSavedConfirmed] = useState(false);
+  const [showSavedError, setShowSavedError] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const stepIndex = STEPS.indexOf(step);
+  const totalSteps = STEPS.length;
+  const nextStepLabel = NEXT_STEP_LABELS[step];
+
+  const [generateSetup, { loading: generating, error: generateError }] =
+    useMutation(GENERATE_TOTP_SETUP);
+
+  const [
+    confirmSetup,
+    { loading: confirming, error: confirmError, reset: resetConfirmError }
+  ] = useMutation(CONFIRM_TOTP_SETUP);
+
+  const goToQrCode = async () => {
+    if (!appInstalled) {
+      setShowAppError(true);
+      return;
+    }
+    const { data } = await generateSetup();
+    if (data?.generateTotpSetup) {
+      setSecret(data.generateTotpSetup.secret);
+      setQrCodeUrl(data.generateTotpSetup.qrCodeUrl);
+      setStep("qrcode");
+    }
+  };
+
+  const handleConfirmCode = async () => {
+    const { data } = await confirmSetup({ variables: { code: totpCode } });
+    if (data?.confirmTotpSetup?.codes) {
+      setRecoveryCodes(data.confirmTotpSetup.codes);
+      setStep("recovery");
+    }
+  };
+
+  const handleCopyCodes = () => {
+    navigator.clipboard.writeText(recoveryCodes.join("\n"));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDownloadCodes = () => {
+    const content = [
+      "Codes de récupération Trackdéchets",
+      "====================================",
+      "Conservez ces codes en lieu sûr.",
+      "Chaque code est à usage unique.",
+      "",
+      ...recoveryCodes
+    ].join("\n");
+
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "trackdechets-recovery-codes.txt";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleFinish = () => {
+    if (!savedConfirmed) {
+      setShowSavedError(true);
+      return;
+    }
+    setStep("success");
+  };
+
+  const title = "Activez l'authentification TOTP";
+
+  return (
+    <TdModal isOpen onClose={onClose} ariaLabel={title} title={title} size="L">
+      {/* Stepper DSFR */}
+      <div className="fr-stepper fr-mb-3w">
+        <h2 className="fr-stepper__title">
+          {STEP_LABELS[step]}
+          <span className="fr-stepper__state">
+            Étape {stepIndex + 1} sur {totalSteps}
+          </span>
+        </h2>
+        <div
+          className="fr-stepper__steps"
+          data-fr-current-step={stepIndex + 1}
+          data-fr-steps={totalSteps}
+        />
+        {nextStepLabel && (
+          <p className="fr-stepper__details">
+            <span className="fr-text--bold">Étape suivante :</span>{" "}
+            {nextStepLabel}
+          </p>
+        )}
+      </div>
+
+      {/* Étape 1 : Explication */}
+      {step === "explanation" && (
+        <div>
+          <p>
+            Un code unique vous sera demandé à chaque nouvelle session. Pour
+            l'obtenir, vous devez utiliser une application mobile.
+          </p>
+          <p>
+            Si vous n'avez pas encore d'application, nous vous conseillons
+            d'utiliser l'outil opensource{" "}
+            <a
+              href="https://freeotp.github.io/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              FreeOTP Authenticator
+            </a>
+            .
+          </p>
+
+          {generateError && (
+            <DsfrNotificationError apolloError={generateError} />
+          )}
+
+          {/* Checkbox avec validation au clic (bouton non bloqué) */}
+          <div
+            className={`fr-checkbox-group fr-mb-3w${
+              showAppError ? " fr-checkbox-group--error" : ""
+            }`}
+          >
+            <input
+              type="checkbox"
+              id="app-installed"
+              className="fr-checkbox-group__input"
+              checked={appInstalled}
+              onChange={e => {
+                setAppInstalled(e.target.checked);
+                if (e.target.checked) setShowAppError(false);
+              }}
+            />
+            <label className="fr-label" htmlFor="app-installed">
+              J'ai installé une application d'authentification sur mon
+              smartphone
+            </label>
+            {showAppError && (
+              <p className="fr-error-text">
+                Merci de bien vouloir prendre connaissance et cocher la case
+                pour continuer.
+              </p>
+            )}
+          </div>
+
+          <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline">
+            <Button priority="secondary" onClick={onClose}>
+              Annuler
+            </Button>
+            <Button disabled={generating} onClick={goToQrCode}>
+              Continuer
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Étape 2 : QR code + saisie du code (fusionnés) */}
+      {step === "qrcode" && (
+        <div>
+          <p className="fr-text--bold">
+            Scannez ce QRcode avec votre application
+          </p>
+
+          {qrCodeUrl && (
+            <div className="fr-mb-2w" style={{ textAlign: "center" }}>
+              <QRCode value={qrCodeUrl} size={180} />
+            </div>
+          )}
+
+          {/* Clé manuelle : lien toggle simple, pas d'Accordion */}
+          {secret && (
+            <div className="fr-mb-3w">
+              <button
+                type="button"
+                className="fr-link"
+                onClick={() => setShowManualKey(v => !v)}
+                aria-expanded={showManualKey}
+              >
+                Vous ne pouvez pas scanner le code ?
+              </button>
+              {showManualKey && (
+                <div className="fr-mt-1w fr-text--sm">
+                  <p className="fr-mb-1w">
+                    Pour configurer manuellement votre application
+                    d'authentification mobile :
+                  </p>
+                  <p className="fr-mb-0">
+                    <strong>Clé/secret :</strong>{" "}
+                    <code style={{ wordBreak: "break-all" }}>{secret}</code>
+                  </p>
+                  <p className="fr-mb-0">
+                    <strong>Type :</strong> TOTP
+                  </p>
+                  <p className="fr-mb-0">
+                    <strong>Algorithme :</strong> SHA1
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Input avec état d'erreur DSFR natif */}
+          <div className="fr-col-md-8">
+            <Input
+              label="Insérez le code généré par votre application"
+              hintText="Entrez le code à usage unique"
+              state={confirmError ? "error" : "default"}
+              stateRelatedMessage={
+                confirmError ? "Le code est incorrect" : undefined
+              }
+              nativeInputProps={{
+                value: totpCode,
+                onChange: e => {
+                  setTotpCode(e.target.value);
+                  // Efface l'erreur dès que l'utilisateur modifie le champ
+                  if (confirmError) resetConfirmError();
+                },
+                inputMode: "numeric",
+                pattern: "[0-9]*",
+                maxLength: 6,
+                autoComplete: "one-time-code",
+                placeholder: "ex: 123456"
+              }}
+            />
+          </div>
+
+          <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-mt-3w">
+            <Button priority="secondary" onClick={() => setStep("explanation")}>
+              Précédent
+            </Button>
+            <Button
+              disabled={totpCode.length !== 6 || confirming}
+              onClick={handleConfirmCode}
+            >
+              Continuer
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Étape 3 : Codes de récupération */}
+      {step === "recovery" && (
+        <div>
+          <h3 className="fr-h6 fr-mb-1w">
+            Sauvegardez vos clés de récupération
+          </h3>
+          <p className="fr-mb-3w">
+            Ces clés sont le seul et unique moyen de récupérer votre compte si
+            vous perdez votre téléphone. Nous vous conseillons fortement de les
+            sauvegarder dans un document ou de les imprimer.
+          </p>
+
+          <div className="fr-mb-3w">
+            <div
+              className="fr-p-2w fr-mb-2w"
+              style={{
+                background: "#f6f6f6",
+                borderRadius: 4,
+                fontFamily: "monospace",
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: "0.5rem"
+              }}
+            >
+              {recoveryCodes.map(code => (
+                <span key={code} style={{ letterSpacing: "0.05em" }}>
+                  {code}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <ul className="fr-btns-group fr-btns-group--inline fr-mb-3w">
+            <li>
+              <Button
+                priority="secondary"
+                iconId="fr-icon-download-line"
+                iconPosition="left"
+                onClick={handleDownloadCodes}
+              >
+                Télécharger en .txt
+              </Button>
+            </li>
+            <li>
+              <Button
+                priority="secondary"
+                iconId={
+                  copied ? "fr-icon-check-line" : "fr-icon-clipboard-line"
+                }
+                iconPosition="left"
+                onClick={handleCopyCodes}
+              >
+                {copied ? "Copié !" : "Copier"}
+              </Button>
+            </li>
+          </ul>
+
+          {/* Checkbox avec validation au clic */}
+          <div
+            className={`fr-checkbox-group fr-mb-3w${
+              showSavedError ? " fr-checkbox-group--error" : ""
+            }`}
+          >
+            <input
+              type="checkbox"
+              id="saved-confirmed"
+              className="fr-checkbox-group__input"
+              checked={savedConfirmed}
+              onChange={e => {
+                setSavedConfirmed(e.target.checked);
+                if (e.target.checked) setShowSavedError(false);
+              }}
+            />
+            <label className="fr-label" htmlFor="saved-confirmed">
+              J'ai sauvegardé mes clés de récupération
+            </label>
+            {showSavedError && (
+              <p className="fr-error-text">
+                Merci de bien vouloir prendre connaissance et cocher la case
+                pour continuer.
+              </p>
+            )}
+          </div>
+
+          <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline">
+            <Button onClick={handleFinish}>Activer</Button>
+          </div>
+        </div>
+      )}
+
+      {/* Étape 4 : Confirmation */}
+      {step === "success" && (
+        <div>
+          {/* Bannière succès compacte (pas de title séparé) */}
+          <div className="fr-alert fr-alert--success fr-mb-3w" role="alert">
+            <p>Votre double authentification est bien activée</p>
+          </div>
+          <div className="fr-btns-group fr-btns-group--right">
+            <Button onClick={onSuccess}>Fermer</Button>
+          </div>
+        </div>
+      )}
+    </TdModal>
+  );
+}

--- a/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { gql, useMutation } from "@apollo/client";
 import QRCode from "react-qr-code";
 import { Button } from "@codegouvfr/react-dsfr/Button";
@@ -65,6 +65,7 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
   const [savedConfirmed, setSavedConfirmed] = useState(false);
   const [showSavedError, setShowSavedError] = useState(false);
   const [copied, setCopied] = useState(false);
+  const copyTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   const stepIndex = STEPS.indexOf(step);
   const totalSteps = STEPS.length;
@@ -99,8 +100,20 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
     }
   };
 
-  const handleCopyCodes = () => {
-    navigator.clipboard.writeText(recoveryCodes.join("\n"));
+  const handleCopyCodes = async () => {
+    const text = recoveryCodes.join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Fallback : textarea dans la modal pour éviter le focus trap
+      const el = copyTextareaRef.current;
+      if (el) {
+        el.value = text;
+        el.focus();
+        el.select();
+        document.execCommand("copy");
+      }
+    }
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -133,10 +146,25 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
   };
 
   const title = "Activez l'authentification TOTP";
+  const CopyRecoveryCodeIcone = () => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M11.3333 1.33325V2.66659H13.338C13.7033 2.66659 14 2.96325 14 3.32859V14.0046C13.9996 14.37 13.7035 14.6662 13.338 14.6666H2.662C2.29654 14.6662 2.00037 14.37 2 14.0046V3.32859C2 2.96325 2.29667 2.66659 2.662 2.66659H4.66667V1.33325H11.3333ZM4.66667 3.99992H3.33333V13.3333H12.6667V3.99992H11.3333V5.33325H4.66667V3.99992ZM10 2.66659H6V3.99992H10V2.66659Z"
+        fill="#000091"
+      />
+    </svg>
+  );
 
   return (
     <TdModal isOpen onClose={onClose} ariaLabel={title} title={title} size="L">
-      {/* Stepper DSFR */}
       <div className="fr-stepper fr-mb-3w">
         <h2 className="fr-stepper__title">
           {STEP_LABELS[step]}
@@ -160,17 +188,18 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
       {/* Étape 1 : Explication */}
       {step === "explanation" && (
         <div>
-          <p>
+          <p className="fr-mb-3w">
             Un code unique vous sera demandé à chaque nouvelle session. Pour
             l'obtenir, vous devez utiliser une application mobile.
           </p>
-          <p>
+          <p className="fr-mb-3w">
             Si vous n'avez pas encore d'application, nous vous conseillons
             d'utiliser l'outil opensource{" "}
             <a
               href="https://freeotp.github.io/"
               target="_blank"
               rel="noopener noreferrer"
+              className="fr-link"
             >
               FreeOTP Authenticator
             </a>
@@ -181,9 +210,8 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             <DsfrNotificationError apolloError={generateError} />
           )}
 
-          {/* Checkbox avec validation au clic (bouton non bloqué) */}
           <div
-            className={`fr-checkbox-group fr-mb-3w${
+            className={`fr-checkbox-group fr-mb-2w${
               showAppError ? " fr-checkbox-group--error" : ""
             }`}
           >
@@ -210,8 +238,12 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
           </div>
 
           <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline">
-            <Button priority="secondary" onClick={onClose}>
-              Annuler
+            <Button
+              priority="secondary"
+              disabled={step === "explanation"}
+              onClick={onClose}
+            >
+              Précédent
             </Button>
             <Button disabled={generating} onClick={goToQrCode}>
               Continuer
@@ -223,9 +255,11 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
       {/* Étape 2 : QR code + saisie du code (fusionnés) */}
       {step === "qrcode" && (
         <div>
-          <p className="fr-text--bold">
-            Scannez ce QRcode avec votre application
-          </p>
+          <h3 className="fr-h1">
+            <p className="fr-text--lead">
+              Scannez ce QRcode avec votre application
+            </p>
+          </h3>
 
           {qrCodeUrl && (
             <div className="fr-mb-2w" style={{ textAlign: "center" }}>
@@ -265,11 +299,12 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             </div>
           )}
 
-          {/* Input avec état d'erreur DSFR natif */}
           <div className="fr-col-md-8">
+            <label className="fr-label fr-text--bold fr-²">
+              Insérez le code généré par votre application
+            </label>
             <Input
-              label="Insérez le code généré par votre application"
-              hintText="Entrez le code à usage unique"
+              label="Entrez le code à usage unique"
               state={confirmError ? "error" : "default"}
               stateRelatedMessage={
                 confirmError ? "Le code est incorrect" : undefined
@@ -336,7 +371,7 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             </div>
           </div>
 
-          <ul className="fr-btns-group fr-btns-group--inline fr-mb-3w">
+          <ul className="fr-btns-group--inline fr-mb-3w">
             <li>
               <Button
                 priority="secondary"
@@ -350,12 +385,10 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             <li>
               <Button
                 priority="secondary"
-                iconId={
-                  copied ? "fr-icon-check-line" : "fr-icon-clipboard-line"
-                }
-                iconPosition="left"
                 onClick={handleCopyCodes}
+                className="fr-ml-1w"
               >
+                <CopyRecoveryCodeIcone />
                 {copied ? "Copié !" : "Copier"}
               </Button>
             </li>
@@ -388,7 +421,10 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             )}
           </div>
 
-          <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline">
+          <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-mt-3w">
+            <Button priority="secondary" onClick={() => setStep("recovery")}>
+              Précédent
+            </Button>
             <Button onClick={handleFinish}>Activer</Button>
           </div>
         </div>
@@ -401,11 +437,18 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
           <div className="fr-alert fr-alert--success fr-mb-3w" role="alert">
             <p>Votre double authentification est bien activée</p>
           </div>
-          <div className="fr-btns-group fr-btns-group--right">
+          <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline">
             <Button onClick={onSuccess}>Fermer</Button>
           </div>
         </div>
       )}
+      <textarea
+        ref={copyTextareaRef}
+        aria-hidden="true"
+        readOnly
+        style={{ position: "absolute", left: "-9999px", top: 0, opacity: 0 }}
+        tabIndex={-1}
+      />
     </TdModal>
   );
 }

--- a/front/src/Apps/Account/AccountMenu.tsx
+++ b/front/src/Apps/Account/AccountMenu.tsx
@@ -37,6 +37,18 @@ export const AccountMenuContent = () => (
             Notifications
           </NavLink>
         </li>
+        <li className="tw-mb-1">
+          <NavLink
+            to={routes.account.authentication}
+            className={({ isActive }) =>
+              isActive
+                ? "sidebarv2__item sidebarv2__item--indented sidebarv2__item--active"
+                : "sidebarv2__item sidebarv2__item--indented"
+            }
+          >
+            Authentification
+          </NavLink>
+        </li>
       </ul>
     </Accordion>
 

--- a/front/src/Apps/routes.ts
+++ b/front/src/Apps/routes.ts
@@ -106,6 +106,7 @@ const routes = {
     index: "/account",
     info: "/account/info",
     notifications: "/account/notifications",
+    authentication: "/account/authentication",
     // Old routes to keep integrations from breaking
     companies: {
       create: {
@@ -244,6 +245,7 @@ export const titles = {
   "/account": "Mon compte — Trackdéchets",
   "/account/info": "Informations sur mon compte — Trackdéchets",
   "/account/notifications": "Mes notifications — Trackdéchets",
+  "/account/authentication": "Authentification — Trackdéchets",
   "/account/companies/new":
     "Ajouter un établissement producteur de déchets — Trackdéchets",
   "/account/companies/professional":

--- a/libs/back/mail/src/templates/index.ts
+++ b/libs/back/mail/src/templates/index.ts
@@ -14,6 +14,12 @@ const { UI_HOST } = process.env;
 // URL permettant de gérer les préférences de notifications par e-mail
 const handlePreferencesUrl = `${UI_HOST}/account/notifications`;
 
+export const onTotpActivated: MailTemplate<{ name: string }> = {
+  subject: "Double authentification activée sur votre compte Trackdéchets",
+  body: mustacheRenderer("totp-activated.html"),
+  templateId: templateIds.LAYOUT
+};
+
 export const onSignup: MailTemplate<{ activationHash: string }> = {
   subject: "Activer votre compte sur Trackdéchets",
   body: mustacheRenderer("confirmation-de-compte.html"),

--- a/libs/back/mail/src/templates/mustache/totp-activated.html
+++ b/libs/back/mail/src/templates/mustache/totp-activated.html
@@ -1,0 +1,58 @@
+<p>Bonjour {{name}},</p>
+
+<p>
+  La double authentification (2FA) a bien été activée sur votre compte
+  Trackdéchets.
+</p>
+
+<p>
+  À chaque connexion, vous devrez désormais saisir un code provisoire généré par
+  votre application d'authentification, en plus de votre mot de passe habituel.
+</p>
+
+<br />
+
+<p><strong>Conservez précieusement vos codes de récupération</strong></p>
+
+<p>
+  Lors de l'activation, des codes de récupération à usage unique vous ont été
+  fournis. Ils constituent votre seul moyen de récupérer l'accès à votre compte
+  si vous perdez votre application d'authentification ou votre appareil.
+</p>
+
+<br />
+
+<p><strong>Cette activation ne vient pas de vous ?</strong></p>
+
+<p>
+  Si vous n'êtes pas à l'origine de cette activation, votre compte a peut-être
+  été compromis. Dans ce cas :
+</p>
+<ul>
+  <li>Changez immédiatement votre mot de passe</li>
+  <li>
+    Contactez notre support via
+    <a href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+      >l'Assistance Trackdéchets</a
+    >
+  </li>
+</ul>
+
+<br />
+
+<p>Merci pour votre vigilance.</p>
+
+<p>L'équipe Trackdéchets</p>
+
+<br />
+
+<p>
+  <small>
+    Vous recevez cet e-mail car une modification de sécurité a été effectuée sur
+    le compte associé à cette adresse e-mail. Si vous avez des questions,
+    contactez notre support via
+    <a href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+      >l'Assistance Trackdéchets</a
+    >.
+  </small>
+</p>

--- a/libs/back/prisma/src/migrations/20260413000000_add_totp_recovery_codes/migration.sql
+++ b/libs/back/prisma/src/migrations/20260413000000_add_totp_recovery_codes/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "TotpRecoveryCode" (
+    "id" TEXT NOT NULL,
+    "userId" VARCHAR(30) NOT NULL,
+    "codeHash" TEXT NOT NULL,
+    "usedAt" TIMESTAMPTZ(6),
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TotpRecoveryCode_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TotpRecoveryCode_userId_idx" ON "TotpRecoveryCode"("userId");
+
+-- AddForeignKey
+ALTER TABLE "TotpRecoveryCode" ADD CONSTRAINT "TotpRecoveryCode_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/back/prisma/src/models/main.prisma
+++ b/libs/back/prisma/src/models/main.prisma
@@ -931,6 +931,7 @@ model User {
   trackingConsentUntil DateTime?
 
   AccessToken           AccessToken[]
+  totpRecoveryCodes     TotpRecoveryCode[]
   applications          Application[]
   companyAssociations   CompanyAssociation[]
   featureFlags          FeatureFlag[]
@@ -959,6 +960,15 @@ model User {
   registryChangeAggregates   RegistryChangeAggregate[]
   registryTexsAnalysisFiles  RegistryTexsAnalysisFile[]
   adminRequests              AdminRequest[]             @relation("AdminRequestUser")
+}
+
+model TotpRecoveryCode {
+  id        String    @id @default(cuid())
+  userId    String
+  codeHash  String
+  usedAt    DateTime?
+  createdAt DateTime  @default(now()) @db.Timestamptz(6)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 enum GovernmentPermission {


### PR DESCRIPTION
# Contexte

Cette PR met en place le parcours d’activation de la double authentification (TOTP) dans l’espace **Mon compte > Authentification**, afin de renforcer la sécurité du compte utilisateur. Elle couvre les différentes étapes côté interface, de la génération et l’affichage du secret/QR code jusqu’à la validation de l’activation par l’utilisateur.


# Points de vigilance pour les intégrateurs

### Base de données:
Nouvelle table :  **TotpRecoveryCode**

CREATE TABLE "TotpRecoveryCode" (
    "id"        TEXT NOT NULL PRIMARY KEY,
    "userId"    VARCHAR(30) NOT NULL,   -- FK → User(id) CASCADE DELETE
    "codeHash"  TEXT NOT NULL,          -- hash bcrypt du code, jamais en clair
    "usedAt"    TIMESTAMPTZ,            -- NULL = non utilisé
    "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now()
);
CREATE INDEX "TotpRecoveryCode_userId_idx" ON "TotpRecoveryCode"("userId");

### GraphQL:
 **Nouveaux types :**

| Type | Champs |
|------|--------|
| `TotpSetup` | `secret: String!, qrCodeUrl: String!` |
| `TotpRecoveryCodes` | `codes: [String!]!` |

# Démo

https://github.com/user-attachments/assets/f823f534-515c-4178-acd5-6cfbe7972d08


# Ticket Favro

[Activer la double authentification](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-17921)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB