### PR TITLE
feat(TRA-17922):connection avec 2FA activé

### DIFF
--- a/back/src/__tests__/auth.integration.ts
+++ b/back/src/__tests__/auth.integration.ts
@@ -310,7 +310,7 @@ describe("Second factor", () => {
     });
   });
 
-  it("should deny user when otp is wrong", async () => {
+  it("should deny user when otp is wrong (fail 1 of 5, no lockout)", async () => {
     const totpSeed = "ABCD";
     const user = await userFactory({ totpSeed, totpActivatedAt: new Date() });
 
@@ -324,7 +324,6 @@ describe("Second factor", () => {
 
     const sessionCookie = login.header["set-cookie"][0];
     const cookieValue = sessionCookie.match(cookieRegExp)?.[1];
-    const timestamp = new Date();
     const secondFactor = await request
       .post("/otp")
       .send(`totp=XYZ`) // wrong otp
@@ -335,10 +334,10 @@ describe("Second factor", () => {
       where: { id: user.id }
     });
 
-    // should redirect
+    // should redirect with INVALID_TOTP, no lockout param (only triggered at 5 fails)
     expect(secondFactor.status).toBe(302);
     expect(secondFactor.header.location).toBe(
-      `http://${UI_HOST}/second-factor?errorCode=INVALID_TOTP&lockout=${updatedUser?.totpLockedUntil?.getTime()}`
+      `http://${UI_HOST}/second-factor?errorCode=INVALID_TOTP`
     );
     // rolling session cookie should be kept
     expect(secondFactor.header["set-cookie"][0]).toContain(cookieValue);
@@ -354,20 +353,51 @@ describe("Second factor", () => {
     expect(errors[0].message).toEqual("Vous n'êtes pas connecté.");
 
     expect(updatedUser!.totpFails).toEqual(1);
-
-    // totpLockedUntil is incremented by 5s steps (5000ms)
-    expect(
-      updatedUser!.totpLockedUntil!.getTime() - timestamp.getTime() >= 5 * 1000
-    ).toBe(true);
+    // no lockout for first 4 failures
+    expect(updatedUser!.totpLockedUntil).toBeNull();
   });
 
-  it("should increase lockout when otp is wrong", async () => {
+  it("should not lockout before 5 consecutive fails (fail 2 of 5)", async () => {
     const totpSeed = "ABCD";
     const user = await userFactory({
       totpSeed,
       totpActivatedAt: new Date(),
       totpFails: 1,
-      totpLockedUntil: new Date()
+      totpLockedUntil: null
+    });
+
+    const login = await request
+      .post("/login")
+      .send(`email=${user.email}`)
+      .send(`password=pass`);
+
+    const sessionCookie = login.header["set-cookie"][0];
+    const cookieValue = sessionCookie.match(cookieRegExp)?.[1];
+    const secondFactor = await request
+      .post("/otp")
+      .send(`totp=XYZ`) // wrong otp
+      .send(`password=pass`)
+      .set("Cookie", `${sess.name}=${cookieValue}`);
+
+    const updatedUser = await prisma.user.findUnique({
+      where: { id: user.id }
+    });
+
+    // still INVALID_TOTP, no lockout yet
+    expect(secondFactor.header.location).toBe(
+      `http://${UI_HOST}/second-factor?errorCode=INVALID_TOTP`
+    );
+    expect(updatedUser!.totpFails).toEqual(2);
+    expect(updatedUser!.totpLockedUntil).toBeNull();
+  });
+
+  it("should trigger 5-minute lockout on 5th consecutive fail", async () => {
+    const totpSeed = "ABCD";
+    const user = await userFactory({
+      totpSeed,
+      totpActivatedAt: new Date(),
+      totpFails: 4, // 4 prior fails
+      totpLockedUntil: null
     });
 
     const login = await request
@@ -380,7 +410,7 @@ describe("Second factor", () => {
     const timestamp = new Date();
     const secondFactor = await request
       .post("/otp")
-      .send(`totp=XYZ`) // wrong otp
+      .send(`totp=XYZ`) // wrong otp → 5th fail
       .send(`password=pass`)
       .set("Cookie", `${sess.name}=${cookieValue}`);
 
@@ -388,16 +418,16 @@ describe("Second factor", () => {
       where: { id: user.id }
     });
 
-    expect(secondFactor.header.location).toBe(
-      `http://${UI_HOST}/second-factor?errorCode=INVALID_TOTP&lockout=${updatedUser?.totpLockedUntil?.getTime()}`
-    );
+    // 5th fail → immediate TOTP_LOCKOUT (not INVALID_TOTP)
+    expect(secondFactor.status).toBe(302);
+    expect(secondFactor.header.location).toContain("errorCode=TOTP_LOCKOUT");
+    expect(secondFactor.header.location).toContain("lockout=");
 
-    expect(updatedUser!.totpFails).toEqual(2); // updated fails count
-
-    // updated totpLockedUntil is incremented (2 * 5s)
+    expect(updatedUser!.totpFails).toEqual(5);
+    // lockout must be ~5 minutes (300 seconds) from now
     expect(
       updatedUser!.totpLockedUntil!.getTime() - timestamp.getTime() >=
-        2 * 5 * 1000
+        300 * 1000
     ).toBe(true);
   });
 
@@ -480,6 +510,85 @@ describe("Second factor", () => {
 
     // totpLockedUntil is reset
     expect(updatedUser!.totpLockedUntil).toEqual(null);
+  });
+
+  /**
+   * Test A — Bypass impossible
+   *
+   * Submitting to POST /otp without having gone through POST /login first
+   * (no preloggedUser in session) must redirect to /login with
+   * TOTP_TIMEOUT_OR_MISSING_SESSION — not grant access to the application.
+   *
+   * Criterion: "Il n'est pas possible de contourner l'étape du second facteur"
+   */
+  it("should redirect to login when POST /otp is called without a prior login session", async () => {
+    const totpSeed = "ABCD";
+    const { otp } = TOTP.generate(totpSeed);
+
+    // Submit directly to /otp — no prior /login, no preloggedUser in session
+    const response = await request.post("/otp").send(`totp=${otp}`);
+
+    expect(response.status).toBe(302);
+    expect(response.header.location).toContain(`${UI_HOST}/login`);
+    expect(response.header.location).toContain(
+      "errorCode=TOTP_TIMEOUT_OR_MISSING_SESSION"
+    );
+  });
+
+  /**
+   * Test B — Correct code blocked during active lockout
+   *
+   * After 5 consecutive wrong codes trigger the 5-minute lockout,
+   * submitting a CORRECT code must still be rejected (TOTP_LOCKOUT).
+   * The lockout must not be bypassable with a valid code.
+   *
+   * Criterion: "Le blocage se lève automatiquement à l'issue du délai"
+   * (implicitly: it must NOT lift before the delay, even with a correct code)
+   */
+  it("should reject a correct TOTP code while the 5-minute lockout is active", async () => {
+    const totpSeed = "ABCD";
+    const user = await userFactory({
+      totpSeed,
+      totpActivatedAt: new Date(),
+      totpFails: 4, // 4 prior fails — next wrong code will trigger the lockout
+      totpLockedUntil: null
+    });
+
+    const login = await request
+      .post("/login")
+      .send(`email=${user.email}`)
+      .send(`password=pass`);
+
+    const cookieValue = login.header["set-cookie"][0].match(cookieRegExp)?.[1];
+
+    // 5th wrong code → triggers 5-minute lockout
+    await request
+      .post("/otp")
+      .send(`totp=000000`)
+      .set("Cookie", `${sess.name}=${cookieValue}`);
+
+    // Now submit the CORRECT code — must still be blocked
+    const { otp } = TOTP.generate(totpSeed);
+    const correctDuringLock = await request
+      .post("/otp")
+      .send(`totp=${otp}`)
+      .set("Cookie", `${sess.name}=${cookieValue}`);
+
+    expect(correctDuringLock.status).toBe(302);
+    expect(correctDuringLock.header.location).toContain(
+      "errorCode=TOTP_LOCKOUT"
+    );
+
+    // User must not be authenticated
+    const protectedRes = await request
+      .post("/")
+      .send({ query: "{ me { email } }" })
+      .set("Cookie", `${sess.name}=${cookieValue}`);
+
+    expect(protectedRes.body.data).toBeNull();
+    expect(protectedRes.body.errors[0].message).toEqual(
+      "Vous n'êtes pas connecté."
+    );
   });
 });
 

--- a/back/src/__tests__/totpStrategy.test.ts
+++ b/back/src/__tests__/totpStrategy.test.ts
@@ -1,0 +1,159 @@
+import { TotpStrategy } from "../auth/totpStrategy";
+import { TOTP } from "totp-generator";
+import { Request } from "express";
+import { addMinutes } from "date-fns";
+import { User } from "@td/prisma";
+
+const findUniqueMock = jest.fn();
+const updateMock = jest.fn();
+
+jest.mock("@td/prisma", () => ({
+  ...jest.requireActual("@td/prisma"),
+  prisma: {
+    user: {
+      findUnique: (...args: unknown[]) => findUniqueMock(...args),
+      update: (...args: unknown[]) => updateMock(...args)
+    }
+  }
+}));
+
+jest.mock("../utils", () => ({
+  sanitizeEmail: (email: string) => email.toLowerCase().trim()
+}));
+
+const SEED = "JBSWY3DPEHPK3PXP";
+
+const mockUser = (overrides: Partial<User> = {}): User =>
+  ({
+    id: "user-id-1",
+    email: "test@trackdechets.fr",
+    password: "hashed",
+    name: "Test User",
+    phone: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isActive: true,
+    isAdmin: false,
+    totpSeed: SEED,
+    totpActivatedAt: new Date(),
+    totpFails: 0,
+    totpLockedUntil: null,
+    ...overrides
+  } as User);
+
+const mockRequest = (totp: string): Request =>
+  ({
+    body: { totp },
+    session: {
+      preloggedUser: {
+        userEmail: "test@trackdechets.fr",
+        expire: addMinutes(new Date(), 5)
+      }
+    }
+  } as unknown as Request);
+
+function makeStrategy() {
+  const strategy = new TotpStrategy();
+  const successSpy = jest.fn();
+  const failSpy = jest.fn();
+  strategy.success = successSpy;
+  strategy.fail = failSpy;
+  strategy.error = jest.fn();
+  return { strategy, successSpy, failSpy };
+}
+
+describe("TotpStrategy", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * Test 1 — Drift tolerance
+   *
+   * A code generated in the previous 30-second TOTP window must be accepted.
+   * This handles users whose authenticator app clock is slightly behind.
+   * Without this, a valid code shown right before a window rotation is rejected.
+   */
+  it("should accept a TOTP code generated in the previous 30-second window (drift tolerance)", async () => {
+    // Fix Date.now to a stable value mid-window to avoid boundary flakiness
+    const fixedNow = 1_700_000_015_000; // 15s into a 30s TOTP window
+    jest.spyOn(Date, "now").mockReturnValue(fixedNow);
+
+    const user = mockUser();
+    findUniqueMock.mockResolvedValue(user);
+    updateMock.mockResolvedValue(user); // resetLock call on success
+
+    // Generate the previous window's OTP (same calculation as verifyTotp internally)
+    const { otp: previousOtp } = TOTP.generate(SEED, {
+      timestamp: fixedNow - 30 * 1000
+    });
+
+    const { strategy, successSpy, failSpy } = makeStrategy();
+    await strategy.authenticate(mockRequest(previousOtp));
+
+    expect(successSpy).toHaveBeenCalledWith(user);
+    expect(failSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Test 2 — Lock threshold boundary
+   *
+   * Fail 4 (totpFails was 3) → INVALID_TOTP, no lockout set in DB.
+   * Fail 5 (totpFails was 4) → TOTP_LOCKOUT returned immediately, lockout ~5 min set in DB.
+   *
+   * This is the core rule of TRA-17922: lockout only triggers at the 5th consecutive fail.
+   */
+  it("should return INVALID_TOTP on fail 4 and TOTP_LOCKOUT on fail 5", async () => {
+    const wrongCode = "000000";
+    const timestamp = Date.now();
+
+    // --- Fail 4 (totpFails was 3): no lockout expected ---
+    const userAt3Fails = mockUser({ totpFails: 3, totpLockedUntil: null });
+    findUniqueMock.mockResolvedValue(userAt3Fails);
+    updateMock.mockResolvedValue({});
+
+    const { strategy: s4, failSpy: fail4 } = makeStrategy();
+    await s4.authenticate(mockRequest(wrongCode));
+
+    expect(fail4).toHaveBeenCalledWith({ code: "INVALID_TOTP" }, 401);
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ totpFails: 4, totpLockedUntil: null })
+      })
+    );
+
+    jest.clearAllMocks();
+
+    // --- Fail 5 (totpFails was 4): 5-minute lockout expected ---
+    const userAt4Fails = mockUser({ totpFails: 4, totpLockedUntil: null });
+    findUniqueMock.mockResolvedValue(userAt4Fails);
+    updateMock.mockResolvedValue({});
+
+    const { strategy: s5, failSpy: fail5 } = makeStrategy();
+    await s5.authenticate(mockRequest(wrongCode));
+
+    expect(fail5).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "TOTP_LOCKOUT",
+        lockout: expect.any(Number)
+      }),
+      401
+    );
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          totpFails: 5,
+          totpLockedUntil: expect.any(Date)
+        })
+      })
+    );
+
+    // Verify the lockout duration is ~5 minutes (≥ 299s to allow for test latency)
+    const updateCall = updateMock.mock.calls[0][0];
+    const lockSeconds =
+      (updateCall.data.totpLockedUntil.getTime() - timestamp) / 1000;
+    expect(lockSeconds).toBeGreaterThanOrEqual(299);
+    expect(lockSeconds).toBeLessThan(310); // sanity upper bound
+  });
+});

--- a/back/src/auth/totpStrategy.ts
+++ b/back/src/auth/totpStrategy.ts
@@ -5,23 +5,22 @@ import { prisma, User } from "@td/prisma";
 import { sanitizeEmail } from "../utils";
 import { addSeconds } from "date-fns";
 
-const TOTP_LOCK_FACTOR = 5;
+const TOTP_MAX_FAILS = 5;
+const TOTP_LOCK_SECONDS = 300; // 5 minutes after TOTP_MAX_FAILS consecutive failures
 
-const increaseLock = async (user?: User) => {
-  if (!user) {
-    return null;
-  }
-  if (user.totpLockedUntil && user.totpLockedUntil > new Date()) {
-    // ignore if user tries before lock expiration
-    return null;
-  }
+const increaseLock = async (
+  user: User
+): Promise<{ totpFails: number; totpLockedUntil: Date | null }> => {
   const totpFails = user.totpFails + 1;
-  const totpLockedUntil = addSeconds(new Date(), totpFails * TOTP_LOCK_FACTOR);
+  const totpLockedUntil =
+    totpFails >= TOTP_MAX_FAILS
+      ? addSeconds(new Date(), TOTP_LOCK_SECONDS)
+      : null;
   await prisma.user.update({
     where: { id: user.id },
     data: { totpFails, totpLockedUntil }
   });
-  return totpLockedUntil;
+  return { totpFails, totpLockedUntil };
 };
 
 const resetLock = async (user: User) => {
@@ -40,21 +39,13 @@ export class TotpStrategy extends PassportStrategy {
   /**
    * Authenticate request
    *
-   * This is the core method that Passport will call
-   * when using this strategy
-   *
-   *  Lockout logic:
-   *  - each time a wrong totp is submitted,
-   *      - the `totpFails` count is increased
-   *      - the `totpLockedUntil` is set to `totpFails` * 5 s  in the future
-   *      - the lockout params is returned alongside the error code, allowing the UI to handle the response querytsring and inform the user
-   *  - during lockout period, totp submission are ignored
-   *  - once lockout expired, successful totp submission resets `totpFails` and `totpLockedUntil`
-   *
-   * @param req - The request object
+   * Lockout logic:
+   *  - fails 1 to TOTP_MAX_FAILS-1: INVALID_TOTP, no lockout (user can retry immediately)
+   *  - fail TOTP_MAX_FAILS (5th): TOTP_LOCKOUT, account blocked for TOTP_LOCK_SECONDS (5 min)
+   *  - any attempt during active lockout: TOTP_LOCKOUT returned immediately
+   *  - successful code after expired lockout: resets totpFails and totpLockedUntil
    */
   async authenticate(req: Request): Promise<void> {
-    // Extract credentials from request
     const { totp } = req.body;
     const userEmail = req.session?.preloggedUser?.userEmail;
     const expire = req.session?.preloggedUser?.expire;
@@ -62,12 +53,12 @@ export class TotpStrategy extends PassportStrategy {
     if (!expire || !userEmail) {
       return this.fail({ code: "TOTP_TIMEOUT_OR_MISSING_SESSION" }, 401);
     }
+
     const user = await prisma.user.findUnique({
       where: { email: sanitizeEmail(userEmail) }
     });
 
     if (new Date(expire) < new Date()) {
-      // prelogging expired, user will be redirected to login
       delete req.session.preloggedUser;
       await resetLock(user!);
       return this.fail({ code: "TOTP_TIMEOUT_OR_MISSING_SESSION" }, 401);
@@ -79,17 +70,20 @@ export class TotpStrategy extends PassportStrategy {
 
     if (user?.totpLockedUntil && user.totpLockedUntil > new Date()) {
       const lockout = user.totpLockedUntil.getTime();
-      return this.fail({ code: `TOTP_LOCKOUT`, lockout }, 401);
+      return this.fail({ code: "TOTP_LOCKOUT", lockout }, 401);
     }
 
-    // Call verify function to validate the totp
     try {
       const verifiedUser = await this.verifyTotp(totp, user);
       if (!verifiedUser) {
-        // increase lockout time (fail * TOTP_LOCK_FACTOR seconds)
-        const totpLockedUntil = await increaseLock(user!);
-        const lockout = totpLockedUntil?.getTime();
-        return this.fail({ code: "INVALID_TOTP", lockout }, 401);
+        const { totpFails, totpLockedUntil } = await increaseLock(user!);
+        if (totpFails >= TOTP_MAX_FAILS) {
+          return this.fail(
+            { code: "TOTP_LOCKOUT", lockout: totpLockedUntil!.getTime() },
+            401
+          );
+        }
+        return this.fail({ code: "INVALID_TOTP" }, 401);
       }
       await resetLock(user!);
       this.success(verifiedUser);

--- a/front/src/login/Login.tsx
+++ b/front/src/login/Login.tsx
@@ -54,8 +54,7 @@ function getErrorMessage(errorCode: string): {
 
   if (errorCode === "TOTP_TIMEOUT_OR_MISSING_SESSION") {
     return {
-      description:
-        "Le délai d'attente pour remplir votre code d'authentification est dépassé, merci de recommencer la procédure"
+      description: "Votre session a expiré. Veuillez vous reconnecter."
     };
   }
 

--- a/front/src/login/SecondFactor.tsx
+++ b/front/src/login/SecondFactor.tsx
@@ -10,58 +10,43 @@ import { Input } from "@codegouvfr/react-dsfr/Input";
 import styles from "./Login.module.scss";
 import { envConfig } from "../common/envConfig";
 
-function getErrorMessage(
-  errorCode: string,
-  lockout?: string
-): string | React.JSX.Element {
-  if (errorCode === "INVALID_TOTP") {
-    return <Countdown timestamp={lockout} />;
+function formatDuration(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (minutes > 0 && secs > 0) {
+    return `${minutes} ${minutes > 1 ? "minutes" : "minute"} ${secs} ${
+      secs > 1 ? "secondes" : "seconde"
+    }`;
   }
-  if (errorCode === "MISSING_TOTP") {
-    return "Le code d'authentification est manquant";
+  if (minutes > 0) {
+    return `${minutes} ${minutes > 1 ? "minutes" : "minute"}`;
   }
-  if (errorCode == "TOTP_LOCKOUT") {
-    return <Countdown timestamp={lockout} />;
-  }
-
-  return "Erreur serveur";
+  return `${seconds} ${seconds > 1 ? "secondes" : "seconde"}`;
 }
 
-function Countdown({ timestamp }) {
-  const calculateSeconds = () => {
-    return Math.max(0, Math.floor((timestamp - Date.now()) / 1000));
-  };
+function Countdown({ timestamp }: { timestamp: number }) {
+  const calculateSeconds = () =>
+    Math.max(0, Math.floor((timestamp - Date.now()) / 1000));
 
   const [seconds, setSeconds] = useState(calculateSeconds);
 
   useEffect(() => {
     if (seconds > 0) {
-      const timer = setTimeout(() => {
-        setSeconds(seconds - 1);
-      }, 1000);
-
+      const timer = setTimeout(() => setSeconds(s => s - 1), 1000);
       return () => clearTimeout(timer);
     }
   }, [seconds]);
 
-  return (
-    <span>
-      {seconds > 0
-        ? `Le code d'authentification est invalide. Merci d'attendre ${seconds}  ${
-            seconds > 1 ? "secondes" : "seconde"
-          } avant de faire un nouvel essai.`
-        : "Vous pouvez entrer votre code"}
-    </span>
-  );
+  if (seconds <= 0) {
+    return <span>Vous pouvez réessayer.</span>;
+  }
+  return <span>dans {formatDuration(seconds)}.</span>;
 }
 
 export default function SecondFactor() {
   const location = useLocation();
-
   const [totp, setTotp] = useState("");
-
   const queries = queryString.parse(location.search);
-
   const formRef = createRef<HTMLFormElement>();
   const { VITE_API_ENDPOINT } = envConfig;
 
@@ -71,19 +56,56 @@ export default function SecondFactor() {
       ...(queries.errorCode ? { errorCode, username, lockout } : {}),
       ...(!!returnTo ? { returnTo } : {})
     };
-
     return <Navigate to={{ pathname: routes.secondFactor }} state={state} />;
   }
+
   const { returnTo, errorCode, lockout } = location.state || {};
-
   const code = Array.isArray(errorCode) ? errorCode[0] : errorCode;
+  const lockoutTimestamp = lockout ? Number(lockout) : undefined;
 
-  const alert = code ? (
-    <div className="fr-grid-row fr-mb-2w">
+  const isLockout = code === "TOTP_LOCKOUT";
+  const isAccountSuspended = code === "ACCOUNT_SUSPENDED";
+  const isInvalidTotp = code === "INVALID_TOTP" || code === "MISSING_TOTP";
+
+  const topAlert = isLockout ? (
+    <div className="fr-grid-row fr-mb-3w">
       <Alert
-        title="Erreur"
-        description={getErrorMessage(code, lockout)}
-        severity="error"
+        title="Blocage temporaire"
+        description={
+          <>
+            Suite aux 5 tentatives successives en erreur, la connexion est
+            temporairement bloquée. Merci de bien vouloir réessayer{" "}
+            {lockoutTimestamp ? (
+              <Countdown timestamp={lockoutTimestamp} />
+            ) : (
+              "dans 5 minutes."
+            )}
+          </>
+        }
+        severity="warning"
+      />
+    </div>
+  ) : isAccountSuspended ? (
+    <div className="fr-grid-row fr-mb-3w">
+      <Alert
+        title="Compte suspendu"
+        description={
+          <>
+            Votre compte est temporairement suspendu dans le cadre d'une
+            procédure de récupération en cours. Si vous n'êtes pas à l'origine
+            de cette demande, contactez notre support via l'Assistance
+            Trackdéchets.{" "}
+            <a
+              href="https://faq.trackdechets.fr/contact"
+              className="fr-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Contacter l'assistance
+            </a>
+          </>
+        }
+        severity="warning"
       />
     </div>
   ) : null;
@@ -97,8 +119,7 @@ export default function SecondFactor() {
         name="login"
       >
         <div className={`fr-container fr-pt-10w ${styles.totpContainer}`}>
-          {/*<Alert title="Erreur" description={Countdown({lockout})} severity="error" />*/}
-          {alert}
+          {topAlert}
           <div className="fr-grid-row fr-grid-row--center fr-mb-2w">
             <div className="fr-col fr-m-auto">
               <h1 className="fr-h3 fr-mb-3w">
@@ -113,23 +134,49 @@ export default function SecondFactor() {
               )}
 
               <Input
+                state={isInvalidTotp ? "error" : "default"}
+                stateRelatedMessage={
+                  isInvalidTotp
+                    ? "Code incorrect. Veuillez vérifier le code affiché dans votre application."
+                    : undefined
+                }
                 nativeInputProps={{
                   value: totp,
                   name: "totp",
-                  autoComplete: "one-time-code", // to allow passwords managers autocompletion
+                  autoComplete: "one-time-code",
                   inputMode: "numeric",
                   pattern: "[0-9]*",
                   maxLength: 6,
                   required: true,
-                  placeholder: "ex: 123456",
+                  placeholder: "Entrez le code à usage unique",
                   onChange: e => setTotp(e.target.value)
                 }}
-                label="Code d’authentification"
+                label="Code d'identification"
               />
+
+              {/* TRA-17923 : ce bouton ouvrira la modale de récupération */}
+              <button
+                type="button"
+                className="fr-link fr-mb-2w"
+                onClick={() => {
+                  /* TODO TRA-17923 */
+                }}
+              >
+                Je n'ai pas accès à l'application
+              </button>
             </div>
           </div>
-          <div className="fr-grid-row fr-grid-row--right">
+
+          <div className="fr-grid-row fr-grid-row--right fr-mt-2w">
             <div className={`fr-col ${styles.resetFlexCol}`}>
+              <Button
+                size="medium"
+                priority="secondary"
+                linkProps={{ href: routes.login }}
+                className="fr-mr-2w"
+              >
+                Annuler
+              </Button>
               <Button size="medium" nativeButtonProps={{ type: "submit" }}>
                 Se connecter
               </Button>


### PR DESCRIPTION
# Contexte

Cette PR ajoute l’étape de validation TOTP dans le parcours de connexion des comptes MFA, avec une session intermédiaire sécurisée, un contrôle des tentatives échouées et une expiration automatique avant accès complet à la plateforme.

# Démo

https://github.com/user-attachments/assets/a4625c73-2cf9-4769-acac-6b3142db1159


# Ticket Favro

[Se connecter avec la double authentification activée](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-17922)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB