### PR TITLE
Tra 17924: Désactiver la double authentification

### DIFF
--- a/back/src/users/resolvers/Mutation.ts
+++ b/back/src/users/resolvers/Mutation.ts
@@ -3,6 +3,7 @@ import signup from "./mutations/signup";
 import changePassword from "./mutations/changePassword";
 import generateTotpSetup from "./mutations/generateTotpSetup";
 import confirmTotpSetup from "./mutations/confirmTotpSetup";
+import disableTotp from "./mutations/disableTotp";
 import createPasswordResetRequest from "./mutations/createPasswordResetRequest";
 import resendActivationEmail from "./mutations/resendActivationEmail";
 import editProfile from "./mutations/editProfile";
@@ -48,7 +49,8 @@ const Mutation: MutationResolvers = {
   subscribeToCompanyNotifications,
   subscribeToNotifications,
   generateTotpSetup,
-  confirmTotpSetup
+  confirmTotpSetup,
+  disableTotp
 };
 
 export default Mutation;

--- a/back/src/users/resolvers/mutations/disableTotp.ts
+++ b/back/src/users/resolvers/mutations/disableTotp.ts
@@ -1,0 +1,102 @@
+import { compare } from "bcrypt";
+import { TOTP } from "totp-generator";
+import { prisma } from "@td/prisma";
+import { applyAuthStrategies, AuthType } from "../../../auth/auth";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import type { MutationResolvers } from "@td/codegen-back";
+import { UserInputError } from "../../../common/errors";
+import { sendMail } from "../../../mailer/mailing";
+import { onTotpDisabled, renderMail } from "@td/mail";
+
+function verifyTotpCode(seed: string, code: string): boolean {
+  const { otp } = TOTP.generate(seed);
+  const thirtySecondsAgo = Date.now() - 30 * 1000;
+  const { otp: lastOtp } = TOTP.generate(seed, { timestamp: thirtySecondsAgo });
+  return [otp, lastOtp].includes(code);
+}
+
+async function findValidRecoveryCode(
+  userId: string,
+  code: string
+): Promise<string | null> {
+  const normalized = code.replace(/-/g, "").toUpperCase();
+  const recoveryCodes = await prisma.totpRecoveryCode.findMany({
+    where: { userId, usedAt: null }
+  });
+
+  for (const rc of recoveryCodes) {
+    if (await compare(normalized, rc.codeHash)) {
+      return rc.id;
+    }
+  }
+  return null;
+}
+
+/**
+ * Désactive le TOTP sur le compte de l'utilisateur connecté.
+ * Nécessite un code TOTP valide ou un code de récupération pour confirmer l'action.
+ * Révoque le secret TOTP et invalide tous les codes de récupération.
+ * Envoie un e-mail de notification de désactivation.
+ * Les sessions actives sur d'autres appareils ne sont pas révoquées.
+ */
+const disableTotpResolver: MutationResolvers["disableTotp"] = async (
+  _,
+  { code },
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  const user = checkIsAuthenticated(context);
+
+  const dbUser = await prisma.user.findUniqueOrThrow({
+    where: { id: user.id }
+  });
+
+  if (!dbUser.totpSeed || !dbUser.totpActivatedAt) {
+    throw new UserInputError("Le TOTP n'est pas activé sur ce compte.");
+  }
+
+  const isTotpValid = verifyTotpCode(dbUser.totpSeed, code);
+  const recoveryCodeId = isTotpValid
+    ? null
+    : await findValidRecoveryCode(dbUser.id, code);
+
+  if (!isTotpValid && recoveryCodeId === null) {
+    throw new UserInputError(
+      "Le code est invalide. Vérifiez votre application d'authentification et réessayez."
+    );
+  }
+
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: dbUser.id },
+      data: {
+        totpSeed: null,
+        totpActivatedAt: null,
+        totpFails: 0,
+        totpLockedUntil: null
+      }
+    }),
+    prisma.totpRecoveryCode.deleteMany({ where: { userId: dbUser.id } })
+  ]);
+
+  await sendMail(
+    renderMail(onTotpDisabled, {
+      to: [{ name: dbUser.name, email: dbUser.email }],
+      variables: { name: dbUser.name }
+    })
+  );
+
+  const updatedUser = await prisma.user.findUniqueOrThrow({
+    where: { id: dbUser.id }
+  });
+
+  return {
+    ...updatedUser,
+    // companies et featureFlags sont résolus par leurs field resolvers dédiés
+    companies: [],
+    featureFlags: [],
+    totpEnabled: false
+  };
+};
+
+export default disableTotpResolver;

--- a/front/src/Apps/Account/AccountAuthentication/AccountAuthentication.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/AccountAuthentication.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import TotpSetupWizard from "./TotpSetupWizard";
+import DisableTotpModal from "./DisableTotpModal";
 import { useApolloClient } from "@apollo/client";
 import { GET_ME } from "../Account";
 
@@ -48,10 +49,16 @@ type Props = {
 
 export default function AccountAuthentication({ totpEnabled }: Props) {
   const [showSetupWizard, setShowSetupWizard] = useState(false);
+  const [showDisableModal, setShowDisableModal] = useState(false);
   const client = useApolloClient();
 
   const handleSetupSuccess = () => {
     setShowSetupWizard(false);
+    client.refetchQueries({ include: [GET_ME] });
+  };
+
+  const handleDisableSuccess = () => {
+    setShowDisableModal(false);
     client.refetchQueries({ include: [GET_ME] });
   };
 
@@ -63,7 +70,10 @@ export default function AccountAuthentication({ totpEnabled }: Props) {
             L'authentification TOTP est activée sur votre compte
           </p>
 
-          <Button priority="secondary">
+          <Button
+            priority="secondary"
+            onClick={() => setShowDisableModal(true)}
+          >
             Désactiver l'authentification TOTP
             <LockOpenIcon />
           </Button>
@@ -106,6 +116,13 @@ export default function AccountAuthentication({ totpEnabled }: Props) {
         <TotpSetupWizard
           onSuccess={handleSetupSuccess}
           onClose={() => setShowSetupWizard(false)}
+        />
+      )}
+
+      {showDisableModal && (
+        <DisableTotpModal
+          onSuccess={handleDisableSuccess}
+          onClose={() => setShowDisableModal(false)}
         />
       )}
     </div>

--- a/front/src/Apps/Account/AccountAuthentication/DisableTotpModal.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/DisableTotpModal.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from "react";
+import { gql, useMutation } from "@apollo/client";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import TdModal from "../../common/Components/Modal/Modal";
+
+const DISABLE_TOTP = gql`
+  mutation DisableTotp($code: String!) {
+    disableTotp(code: $code) {
+      id
+      totpEnabled
+    }
+  }
+`;
+
+type Props = {
+  onSuccess: () => void;
+  onClose: () => void;
+};
+
+export default function DisableTotpModal({ onSuccess, onClose }: Props) {
+  const [code, setCode] = useState("");
+  const [useRecoveryCode, setUseRecoveryCode] = useState(false);
+
+  const [disableTotp, { loading, error, reset }] = useMutation(DISABLE_TOTP);
+
+  const handleCodeChange = (value: string) => {
+    setCode(value);
+    if (error) reset();
+  };
+
+  const handleDisable = async () => {
+    const { data } = await disableTotp({ variables: { code } });
+    if (data?.disableTotp) {
+      onSuccess();
+    }
+  };
+
+  const title = "Voulez-vous vraiment désactiver l'authentification TOTP ?";
+
+  const isCodeReady = useRecoveryCode
+    ? code.trim().length > 0
+    : code.length === 6;
+
+  return (
+    <TdModal isOpen onClose={onClose} ariaLabel={title} title={title} size="L">
+      <p className="fr-mb-3w">
+        La désactivation de l'authentification TOTP entraîne une baisse de la
+        protection de votre compte.
+      </p>
+
+      <label className="fr-label fr-mb-1w">
+        {useRecoveryCode
+          ? "Insérez un code de récupération"
+          : "Insérez le code généré par votre application"}
+      </label>
+
+      <Input
+        label={
+          useRecoveryCode
+            ? "Entrez votre code de récupération"
+            : "Entrez le code à usage unique"
+        }
+        state={error ? "error" : "default"}
+        stateRelatedMessage={error ? "Le code est invalide" : undefined}
+        nativeInputProps={{
+          value: code,
+          type: "password",
+          onChange: e => handleCodeChange(e.target.value),
+          ...(useRecoveryCode
+            ? {
+                autoComplete: "off"
+              }
+            : {
+                maxLength: 6,
+                autoComplete: "one-time-code"
+              })
+        }}
+      />
+
+      <button
+        type="button"
+        className="fr-link fr-mb-3w"
+        onClick={() => {
+          setUseRecoveryCode(v => !v);
+          setCode("");
+          if (error) reset();
+        }}
+      >
+        {useRecoveryCode
+          ? "Utiliser le code de mon application"
+          : "Je n'ai pas accès à l'application"}
+      </button>
+
+      <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-mt-3w">
+        <Button priority="secondary" onClick={onClose} disabled={loading}>
+          Ne pas désactiver
+        </Button>
+        <Button onClick={handleDisable} disabled={!isCodeReady || loading}>
+          Désactiver
+        </Button>
+      </div>
+    </TdModal>
+  );
+}

--- a/libs/back/mail/src/templates/index.ts
+++ b/libs/back/mail/src/templates/index.ts
@@ -20,6 +20,12 @@ export const onTotpActivated: MailTemplate<{ name: string }> = {
   templateId: templateIds.LAYOUT
 };
 
+export const onTotpDisabled: MailTemplate<{ name: string }> = {
+  subject: "Double authentification désactivée sur votre compte Trackdéchets",
+  body: mustacheRenderer("totp-disabled.html"),
+  templateId: templateIds.LAYOUT
+};
+
 export const onSignup: MailTemplate<{ activationHash: string }> = {
   subject: "Activer votre compte sur Trackdéchets",
   body: mustacheRenderer("confirmation-de-compte.html"),

--- a/libs/back/mail/src/templates/mustache/totp-disabled.html
+++ b/libs/back/mail/src/templates/mustache/totp-disabled.html
@@ -1,0 +1,60 @@
+<p>Bonjour {{name}},</p>
+
+<p>
+  La double authentification (2FA) vient d'être désactivée sur votre compte
+  Trackdéchets.
+</p>
+
+<p>
+  Votre compte n'est désormais plus protégé par cette vérification
+  supplémentaire. Cela signifie qu'il suffit de votre mot de passe uniquement
+  pour vous connecter.
+</p>
+
+<br />
+
+<p>
+  Si vous êtes à l'origine de cette désactivation, aucune action supplémentaire
+  n'est requise.
+</p>
+
+<br />
+
+<p>
+  <strong>
+    En revanche, si vous n'êtes pas à l'origine de cette modification,
+  </strong>
+  il est possible qu'une tierce personne ait accédé à votre compte. Dans ce cas
+  :
+</p>
+<ul>
+  <li>Changez immédiatement votre mot de passe</li>
+  <li>
+    Réactivez la double authentification depuis vos paramètres de sécurité
+  </li>
+  <li>
+    Contactez notre support via
+    <a href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+      >l'Assistance Trackdéchets</a
+    >
+  </li>
+</ul>
+
+<br />
+
+<p>Merci de votre vigilance.</p>
+
+<p>L'équipe Trackdéchets</p>
+
+<br />
+
+<p>
+  <small>
+    Vous recevez cet e-mail car une modification de sécurité a été effectuée sur
+    le compte associé à cette adresse e-mail. Si vous avez des questions,
+    contactez notre support via
+    <a href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+      >l'Assistance Trackdéchets</a
+    >.
+  </small>
+</p>


### PR DESCRIPTION
# Contexte

Cette PR permet aux utilisateurs ayant activé la MFA de la désactiver depuis Mon compte > Authentification.
Le parcours est sécurisé par une validation du code TOTP, une confirmation explicite, puis la révocation du secret TOTP, l’invalidation des codes de récupération et l’envoi d’un e-mail de notification.

# Points de vigilance pour les intégrateurs


# Démo


https://github.com/user-attachments/assets/3828be13-3e2e-4090-b7ba-029ce7101e1f



# Ticket Favro

[Désactiver la double authentification](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-17924)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB