### PR TITLE
feat(TRA-14096): BSDD : Permettre de modifier les intermédiaires jusqu'à la signature de la réception par la destination - ÉTAPE 2

### DIFF
--- a/back/src/forms/__tests__/edition.integration.ts
+++ b/back/src/forms/__tests__/edition.integration.ts
@@ -522,7 +522,7 @@ describe("checkEditionRules", () => {
     expect(checked).toEqual(true);
   });
 
-  it("should not be possible to change intermediaries when the form is signed by emitter", async () => {
+  it("should be possible to change intermediaries when the form is signed by emitter (before RECEIVED)", async () => {
     const destination = await userWithCompanyFactory("MEMBER");
     const intermediary1 = await userWithCompanyFactory("MEMBER");
     const intermediary2 = await userWithCompanyFactory("MEMBER");
@@ -538,12 +538,10 @@ describe("checkEditionRules", () => {
     const fullForm = await getFullForm(form);
     const input: UpdateFormInput = {
       id: form.id,
-      intermediaries: [toIntermediaryCompany(intermediary2.company)] // try changing the intermediary
+      intermediaries: [toIntermediaryCompany(intermediary2.company)]
     };
     const checkFn = () => checkEditionRules(fullForm, input, destination.user);
-    await expect(checkFn).rejects.toThrow(
-      "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés : intermediaries"
-    );
+    await expect(checkFn()).resolves.toBe(true);
   });
 
   it("should be possible to resend same intermediaries info when the form is is signed by emitter", async () => {

--- a/back/src/forms/edition.ts
+++ b/back/src/forms/edition.ts
@@ -159,7 +159,7 @@ export const editionRules: {
   grouping: "EMISSION",
   transporters: "RECEPTION",
   forwardedIn: "EMISSION",
-  intermediaries: "EMISSION"
+  intermediaries: "RECEPTION"
 };
 
 export async function checkEditionRules(

--- a/back/src/forms/resolvers/mutations/__tests__/markAsAccepted.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsAccepted.integration.ts
@@ -479,14 +479,14 @@ describe("Test Form reception", () => {
       expect.objectContaining({
         subject:
           "Le déchet de l’entreprise company_1 a été partiellement refusé à réception",
-        to: [
+        to: expect.arrayContaining([
           { email: emitter.email, name: emitter.name },
           { email: emitter2.email, name: emitter2.name }
-        ],
-        cc: [
+        ]),
+        cc: expect.arrayContaining([
           { email: recipient.email, name: recipient.name },
           { email: recipient2.email, name: recipient2.name }
-        ]
+        ])
       })
     );
   });

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -293,7 +293,7 @@ describe("Mutation.updateForm", () => {
     expect(errors).toBeUndefined();
   });
 
-  it("should not be possible to update intermediaries when emitter has signed", async () => {
+  it("should not be possible to update intermediaries when form is RECEIVED", async () => {
     const emitter = await userWithCompanyFactory("ADMIN");
     const destination = await userWithCompanyFactory("ADMIN", {
       companyTypes: [CompanyType.WASTEPROCESSOR],
@@ -304,10 +304,11 @@ describe("Mutation.updateForm", () => {
     const form = await formFactory({
       ownerId: emitter.user.id,
       opt: {
-        status: "SIGNED_BY_PRODUCER",
+        status: "RECEIVED",
         emitterCompanySiret: emitter.company.siret,
         recipientCompanySiret: destination.company.siret,
         emittedAt: new Date(),
+        receivedAt: new Date(),
         intermediaries: { create: toIntermediaryCompany(intermediary1) }
       }
     });

--- a/front/src/Apps/Forms/Components/CompanyContactInfo/CompanyContactInfo.tsx
+++ b/front/src/Apps/Forms/Components/CompanyContactInfo/CompanyContactInfo.tsx
@@ -26,7 +26,8 @@ interface CompanyContactInfoProps {
  *
  */
 export default function CompanyContactInfo({
-  fieldName
+  fieldName,
+  disabled
 }: CompanyContactInfoProps) {
   const [, { error: contactError, touched: contactTouched }] = useField({
     name: `${fieldName}.contact`
@@ -48,6 +49,7 @@ export default function CompanyContactInfo({
             {({ field }) => (
               <Input
                 label="Personne à contacter"
+                disabled={disabled}
                 state={contactError && contactTouched ? "error" : "default"}
                 stateRelatedMessage={contactError}
                 nativeInputProps={field}
@@ -62,6 +64,7 @@ export default function CompanyContactInfo({
             {({ field }) => (
               <Input
                 label="Téléphone"
+                disabled={disabled}
                 state={phoneError && phoneTouched ? "error" : "default"}
                 stateRelatedMessage={phoneError}
                 nativeInputProps={field}
@@ -74,6 +77,7 @@ export default function CompanyContactInfo({
             {({ field }) => (
               <Input
                 label="Courriel"
+                disabled={disabled}
                 state={mailError && mailTouched ? "error" : "default"}
                 stateRelatedMessage={mailError}
                 nativeInputProps={{ ...field, type: "email" }}

--- a/front/src/Apps/Forms/Components/IntermediaryList/FormikIntermediaryList.tsx
+++ b/front/src/Apps/Forms/Components/IntermediaryList/FormikIntermediaryList.tsx
@@ -81,7 +81,10 @@ function FormikIntermediaryList({
                       }
                     }}
                   />
-                  <CompanyContactInfo fieldName={`intermediaries.${idx}`} />
+                  <CompanyContactInfo
+                    disabled={disabled}
+                    fieldName={`intermediaries.${idx}`}
+                  />
                   {values.intermediaries.length > 1 && (
                     <button
                       type="button"
@@ -102,6 +105,7 @@ function FormikIntermediaryList({
                   <button
                     type="button"
                     className="fr-btn fr-btn--secondary"
+                    disabled={disabled}
                     onClick={() => {
                       push(getInitialCompany());
                     }}

--- a/front/src/form/bsdd/FormContainer.tsx
+++ b/front/src/form/bsdd/FormContainer.tsx
@@ -26,6 +26,7 @@ export default function FormContainer() {
                 (!!form.emittedAt && !isEmitter));
 
             const disabledAfterTransport = !!form && !!form.takenOverAt;
+            const intermediariesDisabled = !!form?.receivedAt;
 
             return (
               <>
@@ -41,7 +42,12 @@ export default function FormContainer() {
                   disabled={disabledAfterEmission}
                 />
                 <StepContainer
-                  component={Recipient}
+                  component={props => (
+                    <Recipient
+                      {...props}
+                      intermediariesDisabled={intermediariesDisabled}
+                    />
+                  )}
                   title="Destination du déchet"
                   disabled={disabledAfterEmission}
                 />

--- a/front/src/form/bsdd/Recipient.tsx
+++ b/front/src/form/bsdd/Recipient.tsx
@@ -16,7 +16,7 @@ import FormikBroker from "../../Apps/Forms/Components/Broker/FormikBroker";
 import FormikTrader from "../../Apps/Forms/Components/Trader/FormikTrader";
 import FormikIntermediaryList from "../../Apps/Forms/Components/IntermediaryList/FormikIntermediaryList";
 
-export default function Recipient({ disabled }) {
+export default function Recipient({ disabled, intermediariesDisabled }) {
   const { siret } = useParams<{ siret: string }>();
 
   const { values, setFieldValue } = useFormikContext<Form>();
@@ -146,7 +146,7 @@ Il est important car il qualifie les conditions de gestion et de traitement du d
         <FormikIntermediaryList
           bsdType={BsdType.Bsdd}
           siret={siret}
-          disabled={disabled}
+          disabled={intermediariesDisabled}
         />
       </div>
     </>


### PR DESCRIPTION

# Contexte

Le ticket permet d'autoriser la modification des intermédiaires d'un BSDD
jusqu'à la signature de réception par la destination.


# Démo

https://github.com/user-attachments/assets/302d6f50-3d0f-47bb-9fe5-e1619579a5d4

# Ticket Favro

[BSDD : Permettre de modifier les intermédiaires jusqu'à la signature de la réception par la destination - ÉTAPE 2](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-14096)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB