### PR TITLE
fix/TRA-18156:Registre - Permettre à un établissement ayant le profil…

### DIFF
--- a/front/src/dashboard/registry/RegistryV2ExportModalContext.tsx
+++ b/front/src/dashboard/registry/RegistryV2ExportModalContext.tsx
@@ -297,7 +297,8 @@ export const RegistryV2ExportModalProvider: React.FC<{
           CompanyType.WasteCenter,
           CompanyType.Collector,
           CompanyType.Worker,
-          CompanyType.EcoOrganisme
+          CompanyType.EcoOrganisme,
+          CompanyType.DisposalFacility
         ].includes(t)
       ).length > 0
     ) {
@@ -309,7 +310,8 @@ export const RegistryV2ExportModalProvider: React.FC<{
         [
           CompanyType.Wasteprocessor,
           CompanyType.WasteVehicles,
-          CompanyType.Collector
+          CompanyType.Collector,
+          CompanyType.DisposalFacility
         ].includes(t)
       ).length > 0
     ) {


### PR DESCRIPTION
Registre - Permettre à un établissement ayant le profil "Installation de valorisation de terres et sédiments" d’accéder à l’export du registre réglementaire entrant et sortant

# Contexte

Permettre l'export réglementaire du registre entrant, sortant d'un établissement dont le profil est "Installation de valorisation de terres et sédiments"

# Points de vigilance pour les intégrateurs

X

# Démo

<img width="1666" height="905" alt="image" src="https://github.com/user-attachments/assets/0d0bd32a-981a-4ca5-8c8c-b779bf085d57" />
<img width="748" height="725" alt="image" src="https://github.com/user-attachments/assets/10a6fd47-87ce-4d66-8239-898016358074" />


# Ticket Favro

[Registre - Permettre à un établissement ayant le profil "Installation de valorisation de terres et sédiments" d’accéder à l’export du registre réglementaire entrant et sortant](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-18156)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB