### PR TITLE
TRA-17923: Récupérer son compte via un code de récupération

### DIFF
--- a/back/src/auth/auth.ts
+++ b/back/src/auth/auth.ts
@@ -55,7 +55,8 @@ enum LoginErrorCode {
   INVALID_CAPTCHA = "INVALID_CAPTCHA",
   TOTP_TIMEOUT_OR_MISSING_SESSION = "TOTP_TIMEOUT_OR_MISSING_SESSION",
   MISSING_TOTP = "MISSING_TOTP",
-  INVALID_TOTP = "INVALID_TOTP"
+  INVALID_TOTP = "INVALID_TOTP",
+  MFA_RESET_IN_PROGRESS = "MFA_RESET_IN_PROGRESS"
 }
 
 // verbose error message and related errored field
@@ -144,6 +145,11 @@ passport.use(
         if (!user.isActive) {
           return done(null, false, {
             ...getLoginError(username).NOT_ACTIVATED
+          });
+        }
+        if (user.totpSetupRequired) {
+          return done(null, false, {
+            ...{ code: LoginErrorCode.MFA_RESET_IN_PROGRESS, message: "" }
           });
         }
         if (needsTotp) {

--- a/back/src/auth/totpStrategy.ts
+++ b/back/src/auth/totpStrategy.ts
@@ -68,6 +68,10 @@ export class TotpStrategy extends PassportStrategy {
       return this.fail({ code: "MISSING_TOTP" }, 401);
     }
 
+    if (user?.totpSetupRequired) {
+      return this.fail({ code: "ACCOUNT_SUSPENDED" }, 401);
+    }
+
     if (user?.totpLockedUntil && user.totpLockedUntil > new Date()) {
       const lockout = user.totpLockedUntil.getTime();
       return this.fail({ code: "TOTP_LOCKOUT", lockout }, 401);

--- a/back/src/common/typeDefs/common.objects.graphql
+++ b/back/src/common/typeDefs/common.objects.graphql
@@ -49,4 +49,7 @@ type User {
 
   "Indique si l'authentification TOTP est activée sur le compte"
   totpEnabled: Boolean!
+
+  "Indique que l'utilisateur doit reconfigurer son TOTP suite à une récupération de compte"
+  totpSetupRequired: Boolean!
 }

--- a/back/src/routers/auth-router.ts
+++ b/back/src/routers/auth-router.ts
@@ -3,10 +3,18 @@ import passport from "passport";
 import querystring from "querystring";
 import { prisma } from "@td/prisma";
 import { z } from "zod";
+import { compare } from "bcrypt";
+import { addSeconds } from "date-fns";
 import nocache from "../common/middlewares/nocache";
 import { rateLimiterMiddleware } from "../common/middlewares/rateLimiter";
 import { getUIBaseURL, sanitizeEmail } from "../utils";
 import { getSafeReturnTo } from "../common/helpers";
+import { AuthType } from "../auth/auth";
+import { sendMail } from "../mailer/mailing";
+import { onTotpRecoveryUsed, renderMail } from "@td/mail";
+
+const RECOVERY_MAX_FAILS = 3;
+const RECOVERY_LOCK_SECONDS = 3600;
 
 const UI_BASE_URL = getUIBaseURL();
 
@@ -91,6 +99,126 @@ authRouter.post("/otp", (req, res, next) => {
       return res.redirect(`${UI_BASE_URL}${returnTo}`);
     });
   })(req, res, next);
+});
+
+authRouter.post("/recovery", async (req, res) => {
+  const isAjax = req.headers["x-requested-with"] === "fetch";
+  const userEmail = req.session?.preloggedUser?.userEmail;
+  const expire = req.session?.preloggedUser?.expire;
+
+  if (!expire || !userEmail || new Date(expire) < new Date()) {
+    return res.redirect(
+      `${UI_BASE_URL}/login?${querystring.stringify({
+        errorCode: "TOTP_TIMEOUT_OR_MISSING_SESSION"
+      })}`
+    );
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: sanitizeEmail(userEmail) },
+    include: { totpRecoveryCodes: { where: { usedAt: null } } }
+  });
+
+  if (!user) {
+    return res.redirect(
+      `${UI_BASE_URL}/second-factor?${querystring.stringify({
+        errorCode: "TOTP_TIMEOUT_OR_MISSING_SESSION"
+      })}`
+    );
+  }
+
+  if (user.recoveryLockedUntil && user.recoveryLockedUntil > new Date()) {
+    return res.redirect(
+      `${UI_BASE_URL}/second-factor?${querystring.stringify({
+        errorCode: "RECOVERY_LOCKOUT"
+      })}`
+    );
+  }
+
+  const rawCode = String(req.body.recoveryCode ?? "");
+  const normalizedCode = rawCode.replace(/-/g, "").toUpperCase();
+
+  let matchedCodeId: string | null = null;
+  for (const code of user.totpRecoveryCodes) {
+    if (await compare(normalizedCode, code.codeHash)) {
+      matchedCodeId = code.id;
+      break;
+    }
+  }
+
+  if (!matchedCodeId) {
+    const newFails = user.recoveryFails + 1;
+    const locked = newFails >= RECOVERY_MAX_FAILS;
+
+    if (locked) {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          recoveryFails: newFails,
+          recoveryLockedUntil: addSeconds(new Date(), RECOVERY_LOCK_SECONDS)
+        }
+      });
+    } else {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { recoveryFails: newFails }
+      });
+    }
+
+    const errorCode = locked ? "RECOVERY_LOCKOUT" : "INVALID_RECOVERY_CODE";
+
+    if (isAjax) {
+      return res.status(401).json({ errorCode });
+    }
+
+    const queries = {
+      errorCode,
+      ...(req.body.returnTo
+        ? { returnTo: getSafeReturnTo(req.body.returnTo, UI_BASE_URL) }
+        : {})
+    };
+    return res.redirect(
+      `${UI_BASE_URL}/second-factor?${querystring.stringify(queries)}`
+    );
+  }
+
+  const now = new Date();
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: user.id },
+      data: {
+        totpSeed: null,
+        totpActivatedAt: null,
+        totpSetupRequired: true,
+        recoveryFails: 0,
+        recoveryLockedUntil: null,
+        passwordUpdatedAt: now
+      }
+    }),
+    prisma.totpRecoveryCode.updateMany({
+      where: { userId: user.id },
+      data: { usedAt: now }
+    })
+  ]);
+
+  await sendMail(
+    renderMail(onTotpRecoveryUsed, {
+      to: [{ name: user.name, email: user.email }]
+    })
+  );
+
+  req.logIn({ ...user, auth: AuthType.Session } as Express.User, () => {
+    req.session.issuedAt = new Date().toISOString();
+    delete req.session.preloggedUser;
+    const returnTo = getSafeReturnTo(req.body.returnTo, UI_BASE_URL);
+    if (isAjax) {
+      return res.json({
+        success: true,
+        redirectTo: `${UI_BASE_URL}${returnTo}`
+      });
+    }
+    return res.redirect(`${UI_BASE_URL}${returnTo}`);
+  });
 });
 
 authRouter.get("/isAuthenticated", nocache, (req, res) => {

--- a/back/src/users/resolvers/User.ts
+++ b/back/src/users/resolvers/User.ts
@@ -4,13 +4,17 @@ import { prisma } from "@td/prisma";
 import { toGqlCompanyPrivate } from "../../companies/converters";
 
 const userResolvers: UserResolvers = {
-  // Indique si le TOTP est activé sur le compte
   totpEnabled: parent => {
     const p = parent as {
       totpActivatedAt?: Date | null;
       totpSeed?: string | null;
     };
     return !!p.totpActivatedAt && !!p.totpSeed;
+  },
+
+  totpSetupRequired: parent => {
+    const p = parent as { totpSetupRequired?: boolean | null };
+    return p.totpSetupRequired ?? false;
   },
 
   // Returns the list of companies a user belongs to

--- a/back/src/users/resolvers/mutations/confirmTotpSetup.ts
+++ b/back/src/users/resolvers/mutations/confirmTotpSetup.ts
@@ -103,6 +103,7 @@ const confirmTotpSetupResolver: MutationResolvers["confirmTotpSetup"] = async (
       where: { id: dbUser.id },
       data: {
         totpActivatedAt: now,
+        totpSetupRequired: false,
         // Mise à jour de passwordUpdatedAt pour invalider les sessions des autres appareils
         passwordUpdatedAt: now
       }

--- a/back/src/users/resolvers/queries/me.ts
+++ b/back/src/users/resolvers/queries/me.ts
@@ -10,7 +10,8 @@ const meResolver: QueryResolvers["me"] = async (parent, args, context) => {
     isAdmin: user.isAdmin && !!user.totpActivatedAt && !!user.totpSeed,
     companies: [],
     featureFlags: [],
-    totpEnabled: !!user?.totpSeed && !!user?.activatedAt
+    totpEnabled: !!user?.totpSeed && !!user?.totpActivatedAt,
+    totpSetupRequired: user.totpSetupRequired ?? false
   };
 };
 

--- a/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
@@ -29,6 +29,7 @@ type Step = "explanation" | "qrcode" | "recovery" | "success";
 type Props = {
   onSuccess: () => void;
   onClose: () => void;
+  isReconfiguration?: boolean;
 };
 
 const STEP_LABELS: Record<Step, string> = {
@@ -47,8 +48,14 @@ const NEXT_STEP_LABELS: Partial<Record<Step, string>> = {
 
 const STEPS: Step[] = ["explanation", "qrcode", "recovery", "success"];
 
-export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
-  const [step, setStep] = useState<Step>("explanation");
+export default function TotpSetupWizard({
+  onSuccess,
+  onClose,
+  isReconfiguration = false
+}: Props) {
+  const [step, setStep] = useState<Step>(
+    isReconfiguration ? "qrcode" : "explanation"
+  );
 
   // Étape 1
   const [appInstalled, setAppInstalled] = useState(false);
@@ -145,7 +152,9 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
     setStep("success");
   };
 
-  const title = "Activez l'authentification TOTP";
+  const title = isReconfiguration
+    ? "Reconfigurez votre authentification TOTP"
+    : "Activez l'authentification TOTP";
   const CopyRecoveryCodeIcone = () => (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -326,9 +335,14 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
           </div>
 
           <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-mt-3w">
-            <Button priority="secondary" onClick={() => setStep("explanation")}>
-              Précédent
-            </Button>
+            {!isReconfiguration && (
+              <Button
+                priority="secondary"
+                onClick={() => setStep("explanation")}
+              >
+                Précédent
+              </Button>
+            )}
             <Button
               disabled={totpCode.length !== 6 || confirming}
               onClick={handleConfirmCode}

--- a/front/src/common/contexts/AuthContext.tsx
+++ b/front/src/common/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { gql, useQuery } from "@apollo/client";
 import { Query } from "@td/codegen-ui";
 import React, { useContext, useMemo, useCallback } from "react";
+import TotpSetupWizard from "../../Apps/Account/AccountAuthentication/TotpSetupWizard";
 
 type AuthContextType = {
   isAuthenticated: boolean;
@@ -11,6 +12,7 @@ type AuthContextType = {
         isAdmin?: boolean | null;
         trackingConsent: boolean;
         trackingConsentUntil?: string | null;
+        totpSetupRequired?: boolean | null;
       }
     | undefined;
   refreshUser: () => Promise<void>;
@@ -30,6 +32,7 @@ export const GET_ME = gql`
       isAdmin
       trackingConsent
       trackingConsentUntil
+      totpSetupRequired
     }
   }
 `;
@@ -76,9 +79,18 @@ export function AuthProvider({ children }: React.PropsWithChildren<{}>) {
       await refetchMe();
     }
   }, [refetchMe, isAuthenticated]);
+  const mustReconfigureTotp = isAuthenticated && !!user?.totpSetupRequired;
+
   return (
     <AuthContext.Provider value={{ isAuthenticated, user, refreshUser }}>
       {children}
+      {mustReconfigureTotp && (
+        <TotpSetupWizard
+          isReconfiguration
+          onSuccess={refreshUser}
+          onClose={() => undefined}
+        />
+      )}
     </AuthContext.Provider>
   );
 }

--- a/front/src/login/Login.tsx
+++ b/front/src/login/Login.tsx
@@ -58,6 +58,28 @@ function getErrorMessage(errorCode: string): {
     };
   }
 
+  if (errorCode === "MFA_RESET_IN_PROGRESS") {
+    return {
+      title: "MFA en cours de réinitialisation",
+      description: (
+        <>
+          La reconfiguration du MFA est en cours sur votre compte. Merci de
+          vérifier vos e-mails. Si vous n'êtes pas à l'origine de cette demande,
+          contactez notre support via{" "}
+          <a
+            href="https://faq.trackdechets.fr/contact"
+            className="fr-link force-underline-link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            l'Assistance Trackdéchets
+          </a>
+          .
+        </>
+      )
+    };
+  }
+
   return {
     description: "Courriel ou mot de passe incorrect"
   };

--- a/front/src/login/RecoveryCodeModal.tsx
+++ b/front/src/login/RecoveryCodeModal.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from "react";
+import { Alert } from "@codegouvfr/react-dsfr/Alert";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { PasswordInput } from "@codegouvfr/react-dsfr/blocks/PasswordInput";
+import TdModal from "../Apps/common/Components/Modal/Modal";
+import { envConfig } from "../common/envConfig";
+
+type Props = {
+  onClose: () => void;
+  errorCode?: string;
+  returnTo?: string;
+};
+
+export default function RecoveryCodeModal({
+  onClose,
+  errorCode: initialErrorCode,
+  returnTo
+}: Props) {
+  const [code, setCode] = useState("");
+  const [errorCode, setErrorCode] = useState(initialErrorCode);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { VITE_API_ENDPOINT } = envConfig;
+
+  const isInvalidCode = errorCode === "INVALID_RECOVERY_CODE";
+  const isLockout = errorCode === "RECOVERY_LOCKOUT";
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!code.trim() || isLockout || isSubmitting) return;
+
+    setIsSubmitting(true);
+    setErrorCode(undefined);
+
+    try {
+      const body = new URLSearchParams({ recoveryCode: code });
+      if (returnTo) body.append("returnTo", returnTo);
+
+      const response = await fetch(`${VITE_API_ENDPOINT}/recovery`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          "X-Requested-With": "fetch"
+        },
+        body: body.toString(),
+        credentials: "include"
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        setErrorCode(
+          (data as { errorCode?: string }).errorCode ?? "INVALID_RECOVERY_CODE"
+        );
+        return;
+      }
+
+      const data = await response.json().catch(() => ({}));
+      const redirectTo = (data as { redirectTo?: string }).redirectTo ?? "/";
+      window.location.href = redirectTo;
+    } catch {
+      setErrorCode("INVALID_RECOVERY_CODE");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <TdModal
+      isOpen
+      onClose={onClose}
+      ariaLabel="Je n'ai pas accès à l'application"
+      title="Je n'ai pas accès à l'application"
+      size="M"
+    >
+      {isInvalidCode && (
+        <Alert
+          className="fr-mb-3w"
+          title="Clé de récupération incorrecte"
+          description="La clé renseignée est incorrecte, merci de bien vouloir vérifier le code renseigné ou d'en utiliser un autre. Attention 3 tentatives successives en échec déclenchera une suspension du compte."
+          severity="error"
+        />
+      )}
+      {isLockout && (
+        <Alert
+          className="fr-mb-3w"
+          title="Compte suspendu"
+          description={
+            <>
+              Suite aux 3 tentatives successives en erreur. Votre compte est
+              temporairement suspendu, contactez notre support via l'Assistance
+              Trackdéchets.{" "}
+              <a
+                href="https://faq.trackdechets.fr"
+                className="fr-link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Contacter l'assistance
+              </a>
+            </>
+          }
+          severity="error"
+        />
+      )}
+
+      <p className="fr-text--sm fr-mb-2w">
+        Veuillez renseigner la clé de récupération
+      </p>
+
+      <form onSubmit={handleSubmit}>
+        <PasswordInput
+          label="Clé de récupération"
+          messagesHint=""
+          messages={
+            isInvalidCode || isLockout
+              ? [
+                  {
+                    message: "Clé de récupération incorrecte ou déjà utilisée.",
+                    severity: "error"
+                  }
+                ]
+              : []
+          }
+          nativeInputProps={{
+            name: "recoveryCode",
+            value: code,
+            disabled: isLockout,
+            autoComplete: "off",
+            onChange: e => setCode(e.target.value)
+          }}
+        />
+        <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-mt-3w">
+          <Button
+            nativeButtonProps={{ type: "submit" }}
+            disabled={!code.trim() || isLockout || isSubmitting}
+          >
+            {isSubmitting ? "Connexion…" : "Se connecter"}
+          </Button>
+        </div>
+      </form>
+    </TdModal>
+  );
+}

--- a/front/src/login/SecondFactor.tsx
+++ b/front/src/login/SecondFactor.tsx
@@ -6,6 +6,7 @@ import routes from "../Apps/routes";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
+import RecoveryCodeModal from "./RecoveryCodeModal";
 
 import styles from "./Login.module.scss";
 import { envConfig } from "../common/envConfig";
@@ -49,10 +50,24 @@ const isProdSandbox =
 
 export default function SecondFactor() {
   const location = useLocation();
-  const [totp, setTotp] = useState("");
   const queries = queryString.parse(location.search);
   const formRef = createRef<HTMLFormElement>();
   const { VITE_API_ENDPOINT } = envConfig;
+
+  // Compute recovery error before hooks so we can initialize showRecoveryModal
+  const { errorCode: stateErrorCode } = (location.state || {}) as {
+    errorCode?: string;
+  };
+  const stateCode = Array.isArray(stateErrorCode)
+    ? stateErrorCode[0]
+    : stateErrorCode;
+  const isRecoveryErrorInitial =
+    stateCode === "INVALID_RECOVERY_CODE" || stateCode === "RECOVERY_LOCKOUT";
+
+  const [totp, setTotp] = useState("");
+  const [showRecoveryModal, setShowRecoveryModal] = useState(
+    isRecoveryErrorInitial
+  );
 
   if (queries.errorCode || queries.returnTo) {
     const { errorCode, returnTo, username, lockout = 0 } = queries;
@@ -70,6 +85,8 @@ export default function SecondFactor() {
   const isLockout = code === "TOTP_LOCKOUT";
   const isAccountSuspended = code === "ACCOUNT_SUSPENDED";
   const isInvalidTotp = code === "INVALID_TOTP" || code === "MISSING_TOTP";
+  const isRecoveryError =
+    code === "INVALID_RECOVERY_CODE" || code === "RECOVERY_LOCKOUT";
 
   const topAlert = isLockout ? (
     <div className="fr-grid-row fr-mb-3w">
@@ -100,7 +117,7 @@ export default function SecondFactor() {
             de cette demande, contactez notre support via l'Assistance
             Trackdéchets.{" "}
             <a
-              href="https://faq.trackdechets.fr/contact"
+              href="https://faq.trackdechets.fr"
               className="fr-link"
               target="_blank"
               rel="noopener noreferrer"
@@ -116,6 +133,13 @@ export default function SecondFactor() {
 
   return (
     <div className={styles.onboardingWrapper}>
+      {showRecoveryModal && (
+        <RecoveryCodeModal
+          onClose={() => setShowRecoveryModal(false)}
+          errorCode={isRecoveryError ? code : undefined}
+          returnTo={returnTo}
+        />
+      )}
       <form
         ref={formRef}
         action={`${VITE_API_ENDPOINT}/otp`}
@@ -163,9 +187,7 @@ export default function SecondFactor() {
                 <button
                   type="button"
                   className="fr-link fr-mb-2w"
-                  onClick={() => {
-                    /* TODO TRA-17923 */
-                  }}
+                  onClick={() => setShowRecoveryModal(true)}
                 >
                   Je n'ai pas accès à l'application
                 </button>

--- a/libs/back/mail/src/templates/index.ts
+++ b/libs/back/mail/src/templates/index.ts
@@ -20,6 +20,12 @@ export const onTotpActivated: MailTemplate<{ name: string }> = {
   templateId: templateIds.LAYOUT
 };
 
+export const onTotpRecoveryUsed: MailTemplate<{ name: string }> = {
+  subject: "Récupération de votre compte Trackdéchets",
+  body: mustacheRenderer("totp-recovery.html"),
+  templateId: templateIds.LAYOUT
+};
+
 export const onTotpDisabled: MailTemplate<{ name: string }> = {
   subject: "Double authentification désactivée sur votre compte Trackdéchets",
   body: mustacheRenderer("totp-disabled.html"),

--- a/libs/back/mail/src/templates/mustache/totp-recovery.html
+++ b/libs/back/mail/src/templates/mustache/totp-recovery.html
@@ -1,0 +1,57 @@
+<p>Bonjour {{name}},</p>
+
+<p>
+  Une récupération de compte vient d'être effectuée sur votre compte
+  Trackdéchets à l'aide d'un code de récupération.
+</p>
+
+<p>Suite à cette opération :</p>
+<ul>
+  <li>votre ancien second facteur d'authentification a été révoqué</li>
+  <li>vos anciens codes de récupération ont été invalidés</li>
+  <li>
+    un nouveau second facteur et de nouveaux codes de récupération ont été
+    configurés
+  </li>
+</ul>
+
+<br />
+
+<p><strong>Cette récupération ne vient pas de vous ?</strong></p>
+
+<p>
+  Si vous n'êtes pas à l'origine de cette action, votre compte a peut-être été
+  compromis. Dans ce cas, agissez immédiatement :
+</p>
+<ul>
+  <li>Changez votre mot de passe</li>
+  <li>
+    Désactivez puis activez à nouveau la double authentification depuis
+    <em>Mon compte &gt; Authentification</em>
+  </li>
+  <li>
+    Contactez notre support via
+    <a href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+      >l'Assistance Trackdéchets</a
+    >
+  </li>
+</ul>
+
+<br />
+
+<p>Merci pour votre vigilance.</p>
+
+<p>L'équipe Trackdéchets</p>
+
+<br />
+
+<p>
+  <small>
+    Vous recevez cet e-mail car une modification de sécurité a été effectuée sur
+    le compte associé à cette adresse e-mail. Si vous avez des questions,
+    contactez notre support via
+    <a href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+      >l'Assistance Trackdéchets</a
+    >.
+  </small>
+</p>

--- a/libs/back/prisma/src/migrations/20260424000000_add_totp_recovery_fields/migration.sql
+++ b/libs/back/prisma/src/migrations/20260424000000_add_totp_recovery_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "default$default"."User"
+  ADD COLUMN "totpSetupRequired"   BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "recoveryFails"       INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "recoveryLockedUntil" TIMESTAMPTZ(6);

--- a/libs/back/prisma/src/models/main.prisma
+++ b/libs/back/prisma/src/models/main.prisma
@@ -927,6 +927,9 @@ model User {
   totpActivatedAt      DateTime?          @db.Timestamptz(6)
   totpFails            Int                @default(0)
   totpLockedUntil      DateTime?
+  totpSetupRequired    Boolean            @default(false)
+  recoveryFails        Int                @default(0)
+  recoveryLockedUntil  DateTime?
   trackingConsent      Boolean            @default(false)
   trackingConsentUntil DateTime?
 


### PR DESCRIPTION
# Contexte

Ce ticket met en place le parcours de récupération MFA via code de récupération pour les utilisateurs ayant perdu l’accès à leur application d’authentification. Il permet d’utiliser un code valide depuis une modale dédiée, puis force la révocation de l’ancien TOTP, l’invalidation des anciens codes et la reconfiguration complète de la MFA avant de redonner accès à la plateforme.

# Points de vigilance pour les intégrateurs

### Base de données

**Table modifiée : `User` — `migration.sql`**

```sql
ALTER TABLE "default$default"."User"
  ADD COLUMN "totpSetupRequired" BOOLEAN NOT NULL DEFAULT false,
  ADD COLUMN "recoveryFails" INTEGER NOT NULL DEFAULT 0,
  ADD COLUMN "recoveryLockedUntil" TIMESTAMPTZ(6);
```

| Colonne | Type | Rôle |
|---|---|---|
| `totpSetupRequired` | `BOOLEAN DEFAULT false` | Flag : reconfiguration TOTP obligatoire après usage d’un code de récupération |
| `recoveryFails` | `INTEGER DEFAULT 0` | Compteur de tentatives invalides de codes de récupération |
| `recoveryLockedUntil` | `TIMESTAMPTZ` <br> nullable | Date/heure de fin du lockout — `NULL` = pas de lockout actif |

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Récupérer son compte via un code de récupération](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-17923)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB