### PR TITLE
Refonte des ecrans signature emetteur, signature transporteur et signature destinaire

### DIFF
--- a/front/src/Apps/Dashboard/Validation/bsff/BsffJourneySummary.tsx
+++ b/front/src/Apps/Dashboard/Validation/bsff/BsffJourneySummary.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { Bsff, BsffStatus } from "@td/codegen-ui";
+import {
+  Journey,
+  JourneyStop,
+  JourneyStopName,
+  JourneyStopDescription,
+  JourneyStopVariant
+} from "../../../../common/components";
+
+interface BsffJourneySummaryProps {
+  bsff: Bsff;
+}
+
+export function BsffJourneySummary({ bsff }: BsffJourneySummaryProps) {
+  const signedByEmitter = Boolean(bsff.emitter?.emission?.signature?.date);
+
+  let destinationStopVariant: JourneyStopVariant = "incomplete";
+
+  if (
+    [
+      BsffStatus.Processed,
+      BsffStatus.IntermediatelyProcessed,
+      BsffStatus.Refused
+    ].includes(bsff.status)
+  ) {
+    destinationStopVariant = "complete";
+  } else if (
+    (bsff.transporters ?? []).every(t => Boolean(t?.transport?.signature?.date))
+  ) {
+    destinationStopVariant = "active";
+  }
+
+  return (
+    <Journey>
+      <JourneyStop variant={signedByEmitter ? "complete" : "active"}>
+        <JourneyStopName>Émetteur</JourneyStopName>
+        <JourneyStopDescription>
+          {bsff.emitter?.company?.name} ({bsff.emitter?.company?.siret})<br />
+          {bsff.emitter?.company?.address}
+        </JourneyStopDescription>
+      </JourneyStop>
+      {bsff.transporters.map((transporter, idx) => {
+        let variant: JourneyStopVariant = "incomplete";
+        if (transporter?.transport?.signature?.date) {
+          variant = "complete";
+        } else if (
+          (idx > 0 && bsff.transporters[idx - 1].transport?.signature?.date) ||
+          (idx === 0 && signedByEmitter)
+        ) {
+          // Le transporteur est considéré actif s'il est le premier
+          // dans la liste des transporteurs à ne pas encore avoir pris
+          // en charge le déchet après la signature émetteur
+          variant = "active";
+        }
+
+        return (
+          <JourneyStop key={transporter.id} variant={variant}>
+            <JourneyStopName>
+              Transporteur
+              {bsff.transporters.length > 1 ? ` n° ${idx + 1}` : ""}
+            </JourneyStopName>
+
+            <JourneyStopDescription>
+              {transporter?.company?.name} ({transporter?.company?.orgId})
+              <br />
+              {transporter?.company?.address}
+            </JourneyStopDescription>
+          </JourneyStop>
+        );
+      })}
+      <JourneyStop variant={destinationStopVariant}>
+        <JourneyStopName>Destinataire</JourneyStopName>
+        <JourneyStopDescription>
+          {bsff.destination?.company?.name} ({bsff.destination?.company?.siret})
+          <br />
+          {bsff.destination?.company?.address}
+        </JourneyStopDescription>
+      </JourneyStop>
+    </Journey>
+  );
+}

--- a/front/src/Apps/Dashboard/Validation/bsff/BsffWasteSummary.tsx
+++ b/front/src/Apps/Dashboard/Validation/bsff/BsffWasteSummary.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { Bsff } from "@td/codegen-ui";
+import {
+  DsfrDataList,
+  DsfrDataListItem,
+  DsfrDataListTerm,
+  DataListDescription
+} from "../../../../common/components";
+import { PACKAGINGS_NAMES } from "../../../../form/bsff/components/packagings/Packagings";
+
+interface BsffWasteSummaryProps {
+  bsff: Bsff;
+}
+
+export function BsffWasteSummary({ bsff }: BsffWasteSummaryProps) {
+  return (
+    <DsfrDataList>
+      <DsfrDataListItem>
+        <DsfrDataListTerm>BSFF n°</DsfrDataListTerm>
+        <DataListDescription>{bsff.id}</DataListDescription>
+      </DsfrDataListItem>
+      {bsff.packagings?.length === 1 && (
+        <>
+          <DsfrDataListItem>
+            <DsfrDataListTerm>Code déchet</DsfrDataListTerm>
+            <DataListDescription>
+              {bsff.packagings[0].acceptation?.wasteCode ?? bsff.waste?.code}
+            </DataListDescription>
+          </DsfrDataListItem>
+          <DsfrDataListItem>
+            <DsfrDataListTerm>Dénomination usuelle</DsfrDataListTerm>
+            <DataListDescription>
+              {bsff.packagings[0].acceptation?.wasteDescription ??
+                (bsff.waste?.description || "inconnue")}
+            </DataListDescription>
+          </DsfrDataListItem>
+        </>
+      )}
+
+      {bsff.packagings?.length === 1 && (
+        <DsfrDataListItem>
+          <DsfrDataListTerm>Quantité de fluides</DsfrDataListTerm>
+          <DataListDescription>
+            {bsff.packagings[0].acceptation?.weight ?? bsff.weight?.value} kg
+          </DataListDescription>
+        </DsfrDataListItem>
+      )}
+
+      {bsff.packagings?.length === 1 && (
+        <DsfrDataListItem>
+          <DsfrDataListTerm>Contenant</DsfrDataListTerm>
+          <DataListDescription>
+            {bsff.packagings[0].type === "AUTRE"
+              ? bsff.packagings[0].other
+              : PACKAGINGS_NAMES[bsff.packagings[0].type]}{" "}
+            n°
+            {bsff.packagings[0].numero} (
+            {bsff.packagings[0].acceptation?.weight ??
+              bsff.packagings[0].weight}{" "}
+            kg)
+          </DataListDescription>
+        </DsfrDataListItem>
+      )}
+      {bsff.packagings?.length > 1 && (
+        <DsfrDataListItem>
+          <DsfrDataListTerm>Nombre de contenants</DsfrDataListTerm>
+          <DataListDescription>{bsff.packagings.length}</DataListDescription>
+        </DsfrDataListItem>
+      )}
+    </DsfrDataList>
+  );
+}

--- a/front/src/Apps/Dashboard/Validation/bsff/SignBsffEmission.tsx
+++ b/front/src/Apps/Dashboard/Validation/bsff/SignBsffEmission.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import { useMutation, useQuery } from "@apollo/client";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Input from "@codegouvfr/react-dsfr/Input";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { subMonths } from "date-fns";
+import { useForm } from "react-hook-form";
+
+import {
+  BsffSignatureType,
+  Mutation,
+  MutationSignBsffArgs,
+  Query,
+  QueryBsffArgs
+} from "@td/codegen-ui";
+
+import { GET_BSFF_FORM, SIGN_BSFF } from "../../../common/queries/bsff/queries";
+import { Loader } from "../../../common/Components";
+import { NotificationError } from "../../../common/Components/Error/Error";
+import TdModal from "../../../common/Components/Modal/Modal";
+
+import { BsffJourneySummary } from "./BsffJourneySummary";
+import { BsffWasteSummary } from "./BsffWasteSummary";
+
+import { datetimeToYYYYMMDD } from "../../../../common/datetime";
+
+const schema = z.object({
+  author: z
+    .string({
+      required_error: "Le nom et prénom de l'auteur de la signature est requis"
+    })
+    .refine(val => val.trim() !== "", {
+      message: "Le nom et prénom de l'auteur de la signature est requis"
+    })
+    .pipe(
+      z
+        .string()
+        .min(
+          2,
+          "Le nom et prénom de l'auteur de la signature doit comporter au moins 2 caractères"
+        )
+    ),
+
+  date: z.coerce
+    .date({
+      required_error: "La date d'émission est requise",
+      invalid_type_error: "Format de date invalide"
+    })
+    .transform(v => v.toISOString())
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface Props {
+  bsffId: string;
+  onClose: () => void;
+}
+
+export default function SignBsffEmission({ bsffId, onClose }: Props) {
+  const TODAY = new Date();
+
+  const { data } = useQuery<Pick<Query, "bsff">, QueryBsffArgs>(GET_BSFF_FORM, {
+    variables: { id: bsffId },
+    fetchPolicy: "network-only"
+  });
+
+  const [signBsff, { loading, error }] = useMutation<
+    Pick<Mutation, "signBsff">,
+    MutationSignBsffArgs
+  >(SIGN_BSFF);
+
+  const initialState: FormData = {
+    author: "",
+    date: datetimeToYYYYMMDD(TODAY)
+  };
+
+  const { handleSubmit, register, reset, formState } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: initialState
+  });
+
+  if (!data) return <Loader />;
+
+  const { bsff } = data;
+  const title = "Signer le bordereau";
+
+  const onCancel = () => {
+    reset();
+    onClose();
+  };
+
+  const onSubmit = async (formData: FormData) => {
+    await signBsff({
+      variables: {
+        id: bsff.id,
+        input: {
+          type: BsffSignatureType.Emission,
+          author: formData.author,
+          date: formData.date
+        }
+      }
+    });
+
+    reset();
+    onClose();
+  };
+
+  return (
+    <TdModal onClose={onClose} title={title} ariaLabel={title} isOpen size="L">
+      <>
+        {/* SUMMARIES */}
+        <BsffWasteSummary bsff={bsff} />
+        <BsffJourneySummary bsff={bsff} />
+
+        <p className="fr-text fr-mb-2w">
+          En qualité <strong>d'émetteur du déchet</strong>, j'atteste que les
+          informations ci-dessus sont correctes. En signant ce document,
+          j'autorise le transporteur à prendre en charge le déchet.
+        </p>
+
+        {/* FORM */}
+        <form onSubmit={handleSubmit(onSubmit)}>
+          {/* DATE */}
+          <div className="fr-col-8 fr-col-sm-4 fr-mb-2w">
+            <Input
+              label="Date d'émission"
+              nativeInputProps={{
+                type: "date",
+                min: subMonths(TODAY, 2).toISOString().split("T")[0],
+                max: TODAY.toISOString().split("T")[0],
+                ...register("date")
+              }}
+              state={formState.errors.date ? "error" : "default"}
+              stateRelatedMessage={formState.errors.date?.message}
+            />
+          </div>
+
+          {/* AUTHOR */}
+          <div className="fr-col-8 fr-mb-2w">
+            <Input
+              label="Nom et prénom"
+              nativeInputProps={{
+                placeholder: "NOM Prénom",
+                ...register("author")
+              }}
+              state={formState.errors.author ? "error" : "default"}
+              stateRelatedMessage={formState.errors.author?.message}
+            />
+          </div>
+
+          {/* ERROR */}
+          {error && (
+            <div className="fr-mb-4w">
+              <NotificationError apolloError={error} />
+            </div>
+          )}
+
+          <hr className="fr-mt-2w" />
+
+          {/* ACTIONS */}
+          <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline">
+            <Button type="button" priority="secondary" onClick={onCancel}>
+              Annuler
+            </Button>
+
+            <Button disabled={loading} type="submit">
+              {loading ? "Signature en cours..." : "Signer"}
+            </Button>
+          </div>
+        </form>
+      </>
+    </TdModal>
+  );
+}

--- a/front/src/Apps/Dashboard/Validation/bsff/SignBsffReception.tsx
+++ b/front/src/Apps/Dashboard/Validation/bsff/SignBsffReception.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { useMutation, useQuery } from "@apollo/client";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { subMonths } from "date-fns";
+
+import Button from "@codegouvfr/react-dsfr/Button";
+import Input from "@codegouvfr/react-dsfr/Input";
+import { datetimeToYYYYMMDD } from "../../../../common/datetime";
+import {
+  BsffSignatureType,
+  Mutation,
+  MutationSignBsffArgs,
+  MutationUpdateBsffArgs,
+  Query,
+  QueryBsffArgs
+} from "@td/codegen-ui";
+
+import TdModal from "../../../common/Components/Modal/Modal";
+import { NotificationError } from "../../../common/Components/Error/Error";
+
+import {
+  GET_BSFF_FORM,
+  SIGN_BSFF,
+  UPDATE_BSFF_FORM
+} from "../../../common/queries/bsff/queries";
+
+import { BsffWasteSummary } from "./BsffWasteSummary";
+import { BsffJourneySummary } from "./BsffJourneySummary";
+import { Loader } from "../../../common/Components";
+
+const schema = z.object({
+  receptionDate: z.coerce
+    .date({
+      required_error: "La date de réception est requise",
+      invalid_type_error: "Format de date invalide"
+    })
+    .transform(v => v.toISOString()),
+
+  signatureAuthor: z
+    .string({
+      required_error: "Le nom et prénom de l'auteur de la signature est requis"
+    })
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis")
+});
+
+type FormData = z.infer<typeof schema>;
+
+interface Props {
+  bsffId: string;
+  onClose: () => void;
+}
+
+export function SignBsffReception({ bsffId, onClose }: Props) {
+  const TODAY = new Date();
+
+  const { data } = useQuery<Pick<Query, "bsff">, QueryBsffArgs>(GET_BSFF_FORM, {
+    variables: { id: bsffId },
+    fetchPolicy: "network-only"
+  });
+
+  const [updateBsff] = useMutation<
+    Pick<Mutation, "updateBsff">,
+    MutationUpdateBsffArgs
+  >(UPDATE_BSFF_FORM);
+
+  const [signBsff, { loading, error }] = useMutation<
+    Pick<Mutation, "signBsff">,
+    MutationSignBsffArgs
+  >(SIGN_BSFF);
+
+  const methods = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      receptionDate: datetimeToYYYYMMDD(TODAY),
+      signatureAuthor: ""
+    }
+  });
+
+  const { handleSubmit, register, reset, formState } = methods;
+
+  if (!data) return <Loader />;
+
+  const { bsff } = data;
+  const title = "Signer la réception";
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const onSubmit = async (form: FormData) => {
+    await updateBsff({
+      variables: {
+        id: bsff.id,
+        input: {
+          destination: {
+            reception: {
+              date: form.receptionDate
+            }
+          }
+        }
+      }
+    });
+
+    await signBsff({
+      variables: {
+        id: bsff.id,
+        input: {
+          type: BsffSignatureType.Reception,
+          author: form.signatureAuthor,
+          date: form.receptionDate
+        }
+      }
+    });
+
+    reset();
+    onClose();
+  };
+
+  return (
+    <TdModal onClose={onClose} title={title} ariaLabel={title} isOpen size="L">
+      <>
+        <BsffWasteSummary bsff={bsff} />
+        <BsffJourneySummary bsff={bsff} />
+
+        <p className="fr-text fr-mb-2w">
+          En qualité de <strong>destinataire du déchet</strong>, j'atteste que
+          les informations ci-dessus sont correctes. En signant ce document, je
+          déclare réceptionner le déchet.
+        </p>
+
+        <form onSubmit={handleSubmit(onSubmit)}>
+          {/* DATE */}
+          <div className="fr-col-8 fr-col-sm-4 fr-mb-2w">
+            <Input
+              label="Date de réception"
+              nativeInputProps={{
+                type: "date",
+                min: subMonths(TODAY, 2).toISOString().split("T")[0],
+                max: TODAY.toISOString().split("T")[0],
+                ...register("receptionDate")
+              }}
+              state={formState.errors.receptionDate ? "error" : "default"}
+              stateRelatedMessage={formState.errors.receptionDate?.message}
+            />
+          </div>
+
+          {/* AUTHOR */}
+          <div className="fr-col-8 fr-mb-2w">
+            <Input
+              label="Nom et prénom"
+              nativeInputProps={{
+                placeholder: "NOM Prénom",
+                ...register("signatureAuthor")
+              }}
+              state={formState.errors.signatureAuthor ? "error" : "default"}
+              stateRelatedMessage={formState.errors.signatureAuthor?.message}
+            />
+          </div>
+
+          {/* ERROR */}
+          {error && (
+            <div className="fr-mb-4w">
+              <NotificationError apolloError={error} />
+            </div>
+          )}
+
+          <hr className="fr-mt-2w" />
+
+          {/* ACTIONS */}
+          <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline">
+            <Button type="button" priority="secondary" onClick={handleClose}>
+              Annuler
+            </Button>
+
+            <Button disabled={loading} type="submit">
+              {loading ? "Signature en cours..." : "Signer"}
+            </Button>
+          </div>
+        </form>
+      </>
+    </TdModal>
+  );
+}

--- a/front/src/Apps/Dashboard/Validation/bsff/SignBsffTransport.tsx
+++ b/front/src/Apps/Dashboard/Validation/bsff/SignBsffTransport.tsx
@@ -1,0 +1,307 @@
+import { useMutation, useQuery } from "@apollo/client";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Input from "@codegouvfr/react-dsfr/Input";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  BsffSignatureType,
+  FormCompany,
+  Mutation,
+  MutationSignBsffArgs,
+  MutationUpdateBsffTransporterArgs,
+  Query,
+  QueryBsffArgs,
+  TransportMode
+} from "@td/codegen-ui";
+import { subMonths } from "date-fns";
+import React, { useEffect, useMemo } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { z } from "zod";
+import { datetimeToYYYYMMDD } from "../../../../common/datetime";
+import { Loader } from "../../../common/Components";
+import { DsfrNotificationError } from "../../../common/Components/Error/Error";
+import TdModal from "../../../common/Components/Modal/Modal";
+import { BsffJourneySummary } from "./BsffJourneySummary";
+import { BsffWasteSummary } from "./BsffWasteSummary";
+import { GET_BSFF_FORM, SIGN_BSFF } from "../../../common/queries/bsff/queries";
+import { UPDATE_BSFF_TRANSPORTER } from "../../../Forms/Components/query";
+import { RhfTransportModeSelect } from "../../../Forms/Components/TransportMode/TransportMode";
+import { RhfTagsInputWrapper } from "../../../Forms/Components/TagsInput/TagsInputWrapper";
+import TransporterRecepisseWrapper from "../../../../form/common/components/company/TransporterRecepisseWrapper";
+
+const schema = z.object({
+  signature: z.object({
+    author: z
+      .string({
+        required_error:
+          "Le nom et prénom de l'auteur de la signature est requis"
+      })
+      .refine(val => val.trim() !== "", {
+        message: "Le nom et prénom de l'auteur de la signature est requis"
+      })
+      .pipe(
+        z
+          .string()
+          .min(
+            2,
+            "Le nom et prénom de l'auteur de la signature doit comporter au moins 2 caractères"
+          )
+      ),
+    date: z.coerce
+      .date({
+        required_error: "La date d'émission est requise",
+        invalid_type_error: "Format de date invalide."
+      })
+      .transform(v => v?.toISOString())
+  }),
+  company: z.object({
+    contact: z.string().nullish(),
+    phone: z.string().nullish(),
+    mail: z.string().nullish()
+  }),
+  transport: z
+    .object({
+      takenOverAt: z.coerce
+        .date()
+        .nullish()
+        .transform(v => v?.toISOString()),
+      mode: z.string().nullish(),
+      plates: z.preprocess(
+        val => (Array.isArray(val) ? val : [val]).filter(Boolean),
+        z
+          .string()
+          .array()
+
+          .max(2, "2 plaques d'immatriculation maximum")
+      )
+    })
+    .superRefine((val, ctx) => {
+      if (val.mode === "ROAD" && !val.plates?.length) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["plates"],
+          message: `Ce champ est requis pour le transport routier`
+        });
+      }
+    }),
+  recepisse: z
+    .object({
+      isExempted: z.boolean().nullish()
+    })
+    .nullish()
+});
+
+export type ZodBdsaTransport = z.infer<typeof schema>;
+
+const SignBsffTransport = ({ bsffId, onClose }) => {
+  const { data } = useQuery<Pick<Query, "bsff">, QueryBsffArgs>(GET_BSFF_FORM, {
+    variables: {
+      id: bsffId
+    },
+    fetchPolicy: "network-only"
+  });
+
+  const [signBsff, { loading, error }] = useMutation<
+    Pick<Mutation, "signBsff">,
+    MutationSignBsffArgs
+  >(SIGN_BSFF, {});
+
+  const [updateBsffTransporter, { error: updateError }] = useMutation<
+    Pick<Mutation, "updateBsffTransporter">,
+    MutationUpdateBsffTransporterArgs
+  >(UPDATE_BSFF_TRANSPORTER);
+
+  const title = "Signer l'enlèvement";
+  const TODAY = useMemo(() => new Date(), []);
+
+  const signingTransporter = useMemo(
+    () => data?.bsff?.transporters?.find(t => !t.transport?.signature),
+    [data?.bsff]
+  );
+
+  const initialState = {
+    company: signingTransporter?.company as FormCompany,
+    transport: {
+      mode: signingTransporter?.transport?.mode ?? TransportMode.Road,
+      plates: signingTransporter?.transport?.plates ?? [],
+      takenOverAt: signingTransporter?.transport?.takenOverAt
+        ? datetimeToYYYYMMDD(new Date(signingTransporter.transport.takenOverAt))
+        : datetimeToYYYYMMDD(TODAY)
+    },
+    signature: {
+      author: "",
+      date: datetimeToYYYYMMDD(TODAY)
+    }
+  };
+
+  const methods = useForm<ZodBdsaTransport>({
+    defaultValues: initialState, // on garde defaultValues pour eviter une boucle infinie sur signingTransporter
+    resolver: async (data, context, options) => {
+      return zodResolver(schema)(data, context, options);
+    }
+  });
+
+  const { handleSubmit, reset, register, formState } = methods;
+
+  // mettre à jour les valeurs quand signingTransporter est dispo
+  useEffect(() => {
+    if (!signingTransporter) return;
+
+    reset({
+      company: signingTransporter.company as FormCompany,
+      transport: {
+        mode: signingTransporter.transport?.mode ?? TransportMode.Road,
+        plates: signingTransporter.transport?.plates ?? [],
+        takenOverAt: signingTransporter?.transport?.takenOverAt
+          ? datetimeToYYYYMMDD(
+              new Date(signingTransporter.transport.takenOverAt)
+            )
+          : datetimeToYYYYMMDD(TODAY)
+      },
+      signature: {
+        author: "",
+        date: datetimeToYYYYMMDD(TODAY)
+      }
+    });
+  }, [signingTransporter, reset, TODAY]);
+
+  const onCancel = () => {
+    reset();
+    onClose();
+  };
+
+  if (data == null) {
+    return <Loader />;
+  }
+  const { bsff } = data;
+
+  return (
+    <TdModal onClose={onClose} title={title} ariaLabel={title} isOpen size="L">
+      {!signingTransporter ? (
+        <div>Tous les transporteurs ont déjà signé</div>
+      ) : (
+        <>
+          <BsffWasteSummary bsff={bsff} />
+          <BsffJourneySummary bsff={bsff} />
+
+          <FormProvider {...methods}>
+            <form
+              onSubmit={handleSubmit(async data => {
+                const { company, transport, signature } = data;
+                await updateBsffTransporter({
+                  variables: {
+                    id: signingTransporter.id,
+                    //@ts-ignore
+                    input: { transport: transport, company: company }
+                  }
+                });
+                await signBsff({
+                  variables: {
+                    id: bsff.id,
+                    input: {
+                      date: signature.date,
+                      author: signature.author,
+                      type: BsffSignatureType.Transport
+                    }
+                  }
+                });
+                onClose();
+              })}
+            >
+              <h4 className="fr-h4">Transport du déchet</h4>
+              <div className="fr-col-12 fr-col-md-6 fr-mb-2w">
+                <Input
+                  label="Personne à contacter"
+                  nativeInputProps={{
+                    ...register("company.contact")
+                  }}
+                />
+              </div>
+              <div className="fr-grid-row fr-grid-row--gutters fr-mb-2w">
+                <div className="fr-col-12 fr-col-md-4">
+                  <Input
+                    label="Téléphone"
+                    nativeInputProps={{
+                      ...register("company.phone")
+                    }}
+                  />
+                </div>
+                <div className="fr-col-12 fr-col-md-6">
+                  <Input
+                    label="Courriel"
+                    nativeInputProps={{
+                      ...register("company.mail")
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="fr-col-4 fr-mb-5v">
+                <RhfTransportModeSelect fieldPath={"transport.mode"} />
+              </div>
+              <div className="fr-col-8">
+                <RhfTagsInputWrapper
+                  maxTags={2}
+                  label="Immatriculations"
+                  fieldName={"transport.plates"}
+                  hintText="2 max : Véhicule, remorque"
+                />
+              </div>
+
+              <TransporterRecepisseWrapper
+                transporter={signingTransporter}
+                customClass="fr-col-md-11 fr-mb-2w fr-mt-2w"
+              />
+
+              <p className="fr-text fr-mb-2w">
+                En qualité de <strong>transporteur du déchet</strong>, j'atteste
+                que les informations ci-dessus sont correctes. En signant ce
+                document, je déclare prendre en charge le déchet.
+              </p>
+
+              <div className="fr-col-8 fr-col-sm-4 fr-mb-2w">
+                <Input
+                  label="Date de prise en charge"
+                  nativeInputProps={{
+                    type: "date",
+                    min: datetimeToYYYYMMDD(subMonths(TODAY, 2)),
+                    max: datetimeToYYYYMMDD(TODAY),
+                    ...register("transport.takenOverAt")
+                  }}
+                />
+              </div>
+              <div className="fr-col-8 fr-mb-2w">
+                <Input
+                  label="Nom et prénom"
+                  state={
+                    formState.errors.signature?.author ? "error" : "default"
+                  }
+                  nativeInputProps={{
+                    ...register("signature.author")
+                  }}
+                  stateRelatedMessage={
+                    formState.errors.signature?.author?.message
+                  }
+                />
+              </div>
+              <div className="fr-mb-8w">
+                {updateError && (
+                  <DsfrNotificationError apolloError={updateError} />
+                )}
+                {error && <DsfrNotificationError apolloError={error} />}
+              </div>
+
+              <hr className="fr-mt-2w" />
+              <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline">
+                <Button type="button" priority="secondary" onClick={onCancel}>
+                  Annuler
+                </Button>
+                <Button disabled={loading}>Signer</Button>
+              </div>
+            </form>
+          </FormProvider>
+        </>
+      )}
+    </TdModal>
+  );
+};
+
+export default SignBsffTransport;

--- a/front/src/Apps/Dashboard/Validation/workflow/Act/ActBsffValidation.tsx
+++ b/front/src/Apps/Dashboard/Validation/workflow/Act/ActBsffValidation.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Bsff, BsffStatus } from "@td/codegen-ui";
-import { SignEmission } from "../../../../../dashboard/components/BSDList/BSFF/WorkflowAction/SignEmission";
-import { SignTransport } from "../../../../../dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport";
-import { SignReception } from "../../../../../dashboard/components/BSDList/BSFF/WorkflowAction/SignReception";
 import { SignPackagings } from "../../bsff/SignPackagings";
 import SignBsffPackagingModal from "../../bsff/SignBsffPackagingModal";
+import SignBsffEmission from "../../bsff/SignBsffEmission";
+import SignBsffTransport from "../../bsff/SignBsffTransport";
+import { SignBsffReception } from "../../bsff/SignBsffReception";
 
 interface ActBsffValidationProps {
   bsd: Bsff;
@@ -25,11 +25,11 @@ const ActBsffValidation = ({
   };
 
   const renderInitialModal = () => {
-    return <SignEmission bsffId={bsd.id} {...actionButtonAdapterProps} />;
+    return <SignBsffEmission bsffId={bsd.id} onClose={onClose} />;
   };
 
   const renderSignedByEmitterModal = () => {
-    return <SignTransport bsffId={bsd.id} {...actionButtonAdapterProps} />;
+    return <SignBsffTransport bsffId={bsd.id} onClose={onClose} />;
   };
 
   const renderSentModal = () => {
@@ -38,10 +38,10 @@ const ActBsffValidation = ({
     );
 
     if (nextTransporter && nextTransporter.company?.orgId === currentSiret) {
-      return <SignTransport bsffId={bsd.id} {...actionButtonAdapterProps} />;
+      return <SignBsffTransport bsffId={bsd.id} onClose={onClose} />;
     }
 
-    return <SignReception bsffId={bsd.id} {...actionButtonAdapterProps} />;
+    return <SignBsffReception bsffId={bsd.id} onClose={onClose} />;
   };
 
   const renderReceivedModal = () => {


### PR DESCRIPTION
# Contexte

Refonte des ecrans signature emetteur, signature transporteur et signature destinaire

# Points de vigilance pour les intégrateurs

RAS

# Démo


https://github.com/user-attachments/assets/5a8bb8a1-ec6d-458d-8e21-536153912c2d




# Ticket Favro

[BSFF : Mettre la modale de signature de l'émetteur initial au DSFR](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18029)
[BSFF : Mettre la modale de signature du transporteur au DSFR](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18109)
[BSFF : Mettre la modale de signature du destinataire au DSFR](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18110)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB