### PR TITLE
BSFF : Permettre de réviser les informations communes au bordereau BACK et FRONT

### DIFF
--- a/front/src/Apps/Dashboard/Components/Revision/RevisionApproveFragment.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionApproveFragment.tsx
@@ -5,7 +5,8 @@ import {
   Mutation,
   MutationSubmitBsdaRevisionRequestApprovalArgs,
   MutationSubmitFormRevisionRequestApprovalArgs,
-  MutationSubmitBsdasriRevisionRequestApprovalArgs
+  MutationSubmitBsdasriRevisionRequestApprovalArgs,
+  MutationSubmitBsffRevisionRequestApprovalArgs
 } from "@td/codegen-ui";
 import { useMutation } from "@apollo/client";
 import {
@@ -20,6 +21,10 @@ import {
   GET_BSDASRI_REVISION_REQUESTS,
   SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL
 } from "../../../common/queries/reviews/BsdasriReviewQuery";
+import {
+  GET_BSFF_REVISION_REQUESTS,
+  SUBMIT_BSFF_REVISION_REQUEST_APPROVAL
+} from "../../../common/queries/reviews/BsffReviewQuery";
 
 interface RevisionApproveFragmentProps {
   reviewId: string;
@@ -69,6 +74,18 @@ const RevisionApproveFragment = ({
     ]
   });
 
+  const [
+    submitBsffRevisionRequestApproval,
+    { loading: updatingBsff, error: errorBsff }
+  ] = useMutation<
+    Pick<Mutation, "submitBsffRevisionRequestApproval">,
+    MutationSubmitBsffRevisionRequestApprovalArgs
+  >(SUBMIT_BSFF_REVISION_REQUEST_APPROVAL, {
+    refetchQueries: [
+      { query: GET_BSFF_REVISION_REQUESTS, variables: { siret } }
+    ]
+  });
+
   const handleClose = () => onClose!();
 
   const handleRevisionReject = async () => {
@@ -80,6 +97,11 @@ const RevisionApproveFragment = ({
 
     if (bsdType === BsdType.Bsda) {
       await submitBsdaRevisionRequestApproval({
+        variables: { id: reviewId, isApproved: false }
+      });
+    }
+    if (bsdType === BsdType.Bsff) {
+      await submitBsffRevisionRequestApproval({
         variables: { id: reviewId, isApproved: false }
       });
     }
@@ -106,6 +128,12 @@ const RevisionApproveFragment = ({
       });
     }
 
+    if (bsdType === BsdType.Bsff) {
+      await submitBsffRevisionRequestApproval({
+        variables: { id: reviewId, isApproved: true }
+      });
+    }
+
     if (bsdType === BsdType.Bsdasri) {
       await submitBsdasriRevisionRequestApproval({
         variables: { id: reviewId, isApproved: true }
@@ -116,7 +144,7 @@ const RevisionApproveFragment = ({
 
   return (
     <>
-      {(errorBsda || errorForm || errorBsdasri) && (
+      {(errorBsda || errorForm || errorBsdasri || errorBsff) && (
         <div
           style={{ marginTop: "2em", marginBottom: "2em" }}
           className="notification notification--warning"
@@ -124,19 +152,24 @@ const RevisionApproveFragment = ({
           {errorForm?.message}
           {errorBsda?.message}
           {errorBsdasri?.message}
+          {errorBsff?.message}
         </div>
       )}
       <Button
         priority="primary"
         onClick={handleRevisionReject}
-        disabled={updatingForm || updatingBsda || updatingBsdasri}
+        disabled={
+          updatingForm || updatingBsda || updatingBsdasri || updatingBsff
+        }
       >
         Refuser
       </Button>
       <Button
         priority="primary"
         onClick={handleRevisionApprove}
-        disabled={updatingForm || updatingBsda || updatingBsdasri}
+        disabled={
+          updatingForm || updatingBsda || updatingBsdasri || updatingBsff
+        }
       >
         Approuver
       </Button>

--- a/front/src/Apps/Dashboard/Components/Revision/RevisionCancelFragment.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionCancelFragment.tsx
@@ -16,6 +16,10 @@ import {
   GET_BSDASRI_REVISION_REQUESTS
 } from "../../../common/queries/reviews/BsdasriReviewQuery";
 import {
+  CANCEL_BSFF_REVISION_REQUEST,
+  GET_BSFF_REVISION_REQUESTS
+} from "../../../common/queries/reviews/BsffReviewQuery";
+import {
   CANCEL_FORM_REVISION_REQUEST,
   GET_FORM_REVISION_REQUESTS
 } from "../../../common/queries/reviews/BsddReviewsQuery";
@@ -48,6 +52,15 @@ const RevisionCancelFragment = ({
     ]
   });
 
+  const [cancelBsffRevisionRequest, { loading: cancelingBsff }] = useMutation<
+    Pick<Mutation, "cancelBsffRevisionRequest">,
+    MutationCancelBsffRevisionRequestArgs
+  >(CANCEL_BSFF_REVISION_REQUEST, {
+    refetchQueries: [
+      { query: GET_BSFF_REVISION_REQUESTS, variables: { siret } }
+    ]
+  });
+
   const [cancelBsdasriRevisionRequest, { loading: cancelingBsdasri }] =
     useMutation<
       Pick<Mutation, "cancelBsdasriRevisionRequest">,
@@ -69,6 +82,12 @@ const RevisionCancelFragment = ({
 
     if (bsdType === BsdType.Bsda) {
       await cancelBsdaRevisionRequest({
+        variables: { id: reviewId }
+      });
+    }
+
+    if (bsdType === BsdType.Bsff) {
+      await cancelBsffRevisionRequest({
         variables: { id: reviewId }
       });
     }

--- a/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
@@ -12,6 +12,7 @@ import { useLazyQuery } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import { GET_BSDA_REVISION_REQUESTS } from "../../../common/queries/reviews/BsdaReviewQuery";
 import { GET_BSDASRI_REVISION_REQUESTS } from "../../../common/queries/reviews/BsdasriReviewQuery";
+import { GET_BSFF_REVISION_REQUESTS } from "../../../common/queries/reviews/BsffReviewQuery2";
 import { ReviewInterface, mapRevision } from "./revisionMapper";
 import RevisionList from "./RevisionList/RevisionList";
 import { Modal } from "../../../../common/components";

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/BsdaRequestRevisionCancelationInput.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/BsdaRequestRevisionCancelationInput.tsx
@@ -1,0 +1,43 @@
+import { Bsff, BsffStatus } from "@td/codegen-ui";
+import React from "react";
+import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
+import {
+  CANCELATION_MSG,
+  CAN_BE_CANCELLED_LABEL
+} from "../../Revision/wordingsRevision";
+
+// If you modify this, also modify it in the backend
+const CANCELLABLE_BSFF_STATUSES = [
+  // BsffStatus.Initial,
+  BsffStatus.Sent
+  // BsffStatus.Processed,
+  // BsffStatus.Refused,
+  // BsffStatus.AwaitingChild,
+  // BsffStatus.Canceled,
+];
+
+interface Props {
+  bsff: Bsff;
+  onChange: (value) => void;
+}
+
+const CANCELATION_NOT_POSSIBLE_MSG = `Impossible d'annuler ce bordereau. Il est à un statut trop avancé.`;
+
+export function BsffRequestRevisionCancelationInput({ bsff, onChange }: Props) {
+  const canBeCancelled = CANCELLABLE_BSFF_STATUSES.includes(bsff.status);
+
+  return (
+    <>
+      <ToggleSwitch
+        label={CAN_BE_CANCELLED_LABEL}
+        inputTitle="cancellation"
+        disabled={!canBeCancelled}
+        onChange={onChange}
+        helperText={
+          canBeCancelled ? CANCELATION_MSG : CANCELATION_NOT_POSSIBLE_MSG
+        }
+      />
+      <hr className="fr-mt-2w" />
+    </>
+  );
+}

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/BsdaRequestRevisionCancelationInput.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/BsdaRequestRevisionCancelationInput.tsx
@@ -1,0 +1,45 @@
+import { Bsda, BsdaStatus } from "@td/codegen-ui";
+import React from "react";
+import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
+import {
+  CANCELATION_MSG,
+  CAN_BE_CANCELLED_LABEL
+} from "../../../Revision/wordingsRevision";
+
+// If you modify this, also modify it in the backend
+const CANCELLABLE_BSDA_STATUSES = [
+  // BsdaStatus.Initial,
+  BsdaStatus.SignedByProducer,
+  BsdaStatus.SignedByWorker,
+  BsdaStatus.Sent
+  // BsdaStatus.Processed,
+  // BsdaStatus.Refused,
+  // BsdaStatus.AwaitingChild,
+  // BsdaStatus.Canceled,
+];
+
+interface Props {
+  bsda: Bsda;
+  onChange: (value) => void;
+}
+
+const CANCELATION_NOT_POSSIBLE_MSG = `Impossible d'annuler ce bordereau. Il est à un statut trop avancé.`;
+
+export function BsdaRequestRevisionCancelationInput({ bsda, onChange }: Props) {
+  const canBeCancelled = CANCELLABLE_BSDA_STATUSES.includes(bsda.status);
+
+  return (
+    <>
+      <ToggleSwitch
+        label={CAN_BE_CANCELLED_LABEL}
+        inputTitle="cancellation"
+        disabled={!canBeCancelled}
+        onChange={onChange}
+        helperText={
+          canBeCancelled ? CANCELATION_MSG : CANCELATION_NOT_POSSIBLE_MSG
+        }
+      />
+      <hr className="fr-mt-2w" />
+    </>
+  );
+}

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/BsffRequestRevision.module.scss
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/BsffRequestRevision.module.scss
@@ -1,0 +1,52 @@
+@import "../../../../../../scss/Constants.scss";
+@import "../../../../../../scss/Breakpoints.scss";
+
+.container {
+  padding: 2rem 1rem;
+}
+
+.title {
+  font-weight: bold;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+
+.fields {
+  margin-bottom: 2rem;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid $grey;
+  padding: 1rem;
+
+  @include phone {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+  > * {
+    // space buttons and divs
+    margin-left: 1rem;
+    margin-bottom: 1rem;
+    @include phone {
+      margin-bottom: 0;
+    }
+  }
+}
+
+@media only screen and (min-width: 640px) {
+  .actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+}
+
+.cta {
+  display: flex;
+  margin-top: 40px;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 16px;
+  align-self: stretch;
+}

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/BsffRequestRevision.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/BsffRequestRevision.tsx
@@ -1,0 +1,188 @@
+import { useMutation } from "@apollo/client";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Input from "@codegouvfr/react-dsfr/Input";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Bsff,
+  BsdType,
+  Mutation,
+  MutationCreateBsffRevisionRequestArgs
+} from "@td/codegen-ui";
+import React, { useState } from "react";
+import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import { useNavigate, useParams } from "react-router-dom";
+import { z } from "zod";
+import { removeEmptyKeys } from "../../../../../../common/helper";
+import { Loader } from "../../../../../common/Components";
+import { CREATE_BSFF_REVISION_REQUEST } from "../../../../../common/queries/reviews/BsffReviewQuery";
+import { resetPackagingIfUnchanged } from "../../common/Components/Packagings/packagings";
+import RhfReviewableField from "../../common/Components/ReviewableField/RhfReviewableField";
+import {
+  initialBsffReview,
+  validationBsffSchema
+} from "../../common/utils/schema";
+import styles from "./BsffRequestRevision.module.scss";
+import { TITLE_REQUEST_LIST } from "../../../Revision/wordingsRevision";
+import { BsffRequestRevisionCancelationInput } from "../BsdaRequestRevisionCancelationInput";
+type Props = {
+  bsff: Bsff;
+};
+
+export function BsffRequestRevision({ bsff }: Props) {
+  const { siret } = useParams<{ siret: string }>();
+  const navigate = useNavigate();
+  const [createBsffRevisionRequest, { loading, error }] = useMutation<
+    Pick<Mutation, "createBsffRevisionRequest">,
+    MutationCreateBsffRevisionRequestArgs
+  >(CREATE_BSFF_REVISION_REQUEST);
+  const [sealNumbersTags, setSealNumbersTags] = useState<string[]>([]);
+
+  type ValidationSchema = z.infer<typeof validationBsffSchema>;
+
+  const methods = useForm<ValidationSchema>({
+    mode: "onTouched",
+    defaultValues: initialBsffReview,
+    resolver: zodResolver(validationBsffSchema)
+  });
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    reset,
+    formState: { errors, isSubmitting, isDirty }
+  } = methods;
+
+  const resetAndClose = () => {
+    reset();
+    navigate(-1);
+  };
+
+  // Hacky fonction implémentée en hotfix dans tra-15573
+  // La bonne solution à mon sens (benoît) serait d'initialiser
+  // le formulaire de révision avec les valeurs du BSFF
+  // puis de n'envoyer que les champs "dirty" dans onSubmit
+  const resetPopIfUnchanged = (data: Pick<ValidationSchema, "waste">) => {
+    const pop = data?.waste?.pop;
+    if (pop !== null && pop !== undefined && pop === bsff?.waste?.pop) {
+      // aucun changement n'a eu lieu sur le champ pop
+      // on le réinitialise à la valeur par défaut du formulaire
+      data.waste.pop = null;
+    }
+    return data;
+  };
+
+  const checkIfInitialObjectValueChanged = data => {
+    let newData = resetPopIfUnchanged(data);
+    newData = resetPackagingIfUnchanged(
+      data,
+      bsff.packagings,
+      data.packagings,
+      () => delete data.packagings
+    );
+    return newData;
+  };
+
+  const onSubmitForm = async (data: ValidationSchema) => {
+    const { comment, ...content } = data;
+    const cleanedContent = removeEmptyKeys(
+      checkIfInitialObjectValueChanged(content)
+    );
+    await createBsffRevisionRequest({
+      variables: {
+        input: {
+          bsffId: bsff.id,
+          content: cleanedContent ?? {},
+          comment,
+          authoringCompanySiret: siret!
+        }
+      }
+    });
+  };
+
+  const onSubmit: SubmitHandler<ValidationSchema> = async data => {
+    await onSubmitForm(data);
+    resetAndClose();
+  };
+
+  // live form values
+  const formValues = watch();
+
+  const areModificationsDisabled = formValues.isCanceled;
+
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>
+        {TITLE_REQUEST_LIST} {bsff.id}
+      </h2>
+
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className={styles.fields}>
+            <BsffRequestRevisionCancelationInput
+              bsff={bsff}
+              onChange={value => setValue("isCanceled", value)}
+            />
+
+            <div
+              style={{
+                display: areModificationsDisabled ? "none" : "inline"
+              }}
+            >
+              <RhfReviewableField
+                title="CAP"
+                value={bsff.destination?.cap}
+                path="destination.cap"
+                defaultValue={initialBsffReview.destination.cap}
+              >
+                <Input
+                  label="Nouveau CAP (optionnel pour les déchets non dangereux)"
+                  className="fr-col-8"
+                  nativeInputProps={{
+                    ...register("destination.cap")
+                  }}
+                />
+              </RhfReviewableField>
+            </div>
+
+            {!areModificationsDisabled && <hr />}
+
+            <Input
+              textArea
+              label="Commentaire à propos de la révision"
+              state={errors?.comment && "error"}
+              stateRelatedMessage={(errors?.comment?.message as string) ?? ""}
+              nativeTextAreaProps={{
+                ...register("comment")
+              }}
+            />
+
+            {error && (
+              <div className="notification notification--warning">
+                {error.message}
+              </div>
+            )}
+
+            <div className={styles.cta}>
+              <Button
+                priority="secondary"
+                nativeButtonProps={{ type: "button" }}
+                onClick={resetAndClose}
+              >
+                Annuler
+              </Button>
+              <Button
+                type="submit"
+                disabled={!isDirty || loading || isSubmitting}
+              >
+                Demander
+              </Button>
+              {(loading || isSubmitting) && <Loader />}
+            </div>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+}

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/RouteBsffRequestRevision.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/RouteBsffRequestRevision.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from "@apollo/client";
+import { Loader } from "../../../../../common/Components";
+import { InlineError } from "../../../../../common/Components/Error/Error";
+import { GET_BSFF_FORM } from "../../../../../common/queries/bsff/queries";
+import { Query, QueryBsffArgs } from "@td/codegen-ui";
+import React from "react";
+import { useParams } from "react-router-dom";
+import { BsffRequestRevision } from "./BsffRequestRevision";
+
+export function RouteBsffRequestRevision() {
+  const { id } = useParams<{ id: string }>();
+  const { error, data, loading } = useQuery<Pick<Query, "bsff">, QueryBsffArgs>(
+    GET_BSFF_FORM,
+    {
+      variables: {
+        id: id!
+      }
+    }
+  );
+
+  if (error) return <InlineError apolloError={error} />;
+  if (loading) return <Loader />;
+  if (!data?.bsff) return null;
+
+  return <BsffRequestRevision bsff={data?.bsff} />;
+}

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/index.ts
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsff/request/index.ts
@@ -1,0 +1,1 @@
+export * from "./RouteBsffRequestRevision";

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/common/utils/schema.ts
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/common/utils/schema.ts
@@ -297,6 +297,22 @@ export const initialBsdaReview = {
   isCanceled: false
 };
 
+export const initialBsffReview = {
+  emitter: {
+    pickupSite: {
+      name: "",
+      address: "",
+      city: "",
+      postalCode: "",
+      infos: ""
+    }
+  },
+  destination: {
+    cap: ""
+  },
+  isCanceled: false
+};
+
 export const validationBsdaSchema = z.object({
   comment: z.string().min(3, "Le commentaire doit faire au moins 3 caractères"),
   isCanceled: z.boolean().nullish(),
@@ -398,6 +414,26 @@ export const validationBsdaSchema = z.object({
         mode: z.string().nullish(),
         description: z.string().nullish()
       })
+    })
+    .nullish()
+});
+
+export const validationBsffSchema = z.object({
+  comment: z.string().min(3, "Le commentaire doit faire au moins 3 caractères"),
+  isCanceled: z.boolean().nullish(),
+
+  emitter: z.object({
+    pickupSite: z.object({
+      name: z.string().nullish(),
+      address: z.string().nullish(),
+      city: z.string().nullish(),
+      postalCode: z.string().nullish(),
+      infos: z.string().nullish()
+    })
+  }),
+  destination: z
+    .object({
+      cap: z.string().nullish()
     })
     .nullish()
 });

--- a/front/src/Apps/Dashboard/DashboardRoutes.tsx
+++ b/front/src/Apps/Dashboard/DashboardRoutes.tsx
@@ -23,6 +23,8 @@ import { ExtraSignatureType } from "../../dashboard/components/BSDList/BSDasri/t
 import { RouteBsdaRequestRevision } from "./Components/RevisionRequestList/bsda/request";
 import { RouteBsdasriRequestRevision } from "./Components//RevisionRequestList/bsdasri/request";
 import { RouteBsddRequestRevision } from "./Components//RevisionRequestList/bsdd/request/RouteBsddRequestRevision";
+import { RouteBsffRequestRevision } from "./Components/RevisionRequestList/bsff/request";
+
 import {
   RouteBSDasrisView,
   RouteBSDDsView,
@@ -181,6 +183,11 @@ function DashboardRoutes() {
           <Route
             path={toRelative(routes.dashboard.bsdas.review)}
             element={<RouteBsdaRequestRevision />}
+          />
+
+          <Route
+            path={toRelative(routes.dashboard.bsffs.review)}
+            element={<RouteBsffRequestRevision />}
           />
 
           <Route
@@ -480,6 +487,20 @@ function DashboardRoutes() {
                   size={reviewModalSize}
                 >
                   <RouteBsdaRequestRevision />
+                </Modal>
+              }
+            />
+
+            <Route
+              path={toRelative(routes.dashboard.bsffs.review)}
+              element={
+                <Modal
+                  onClose={goBack}
+                  ariaLabel="Demande de révision"
+                  isOpen
+                  size={reviewModalSize}
+                >
+                  <RouteBsffRequestRevision />
                 </Modal>
               }
             />

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1805,6 +1805,24 @@ export const canReviewBsda = (bsd: BsdDisplay, siret: string) => {
   );
 };
 
+export const canReviewBsff = (bsd: BsdDisplay, siret: string) => {
+  if (bsd.type !== BsdType.Bsff || bsd.status === BsdStatusCode.Initial) {
+    return false;
+  }
+
+  const isDestination = isSameSiretDestination(siret, bsd);
+  const isEmitter = isSameSiretEmitter(siret, bsd);
+
+  return (
+    (isEmitter &&
+      // On ne propose pas le bouton "Réviser" à l'émetteur
+      // lorsqu'il est le seul à avoir signé car il peut encore
+      // modifier le BSFF
+      bsd.status !== BsdStatusCode.SignedByProducer) ||
+    isDestination
+  );
+};
+
 export const canReviewBsdasri = (bsd: BsdDisplay, siret: string) => {
   if (
     bsd.type !== BsdType.Bsdasri ||
@@ -1886,7 +1904,8 @@ export const canReviewBsd = (bsd: BsdDisplay, siret: string) => {
   return (
     (bsd.type === BsdType.Bsdd && canReviewBsdd(bsd, siret)) ||
     (bsd.type === BsdType.Bsda && canReviewBsda(bsd, siret)) ||
-    (bsd.type === BsdType.Bsdasri && canReviewBsdasri(bsd, siret))
+    (bsd.type === BsdType.Bsdasri && canReviewBsdasri(bsd, siret)) ||
+    (bsd.type === BsdType.Bsff && canReviewBsff(bsd, siret))
   );
 };
 

--- a/front/src/Apps/Dashboard/dashboardUtils.tsx
+++ b/front/src/Apps/Dashboard/dashboardUtils.tsx
@@ -847,6 +847,8 @@ export const getRevisionPath = bsd => {
       return routes.dashboard.bsdds.review;
     case BsdType.Bsda:
       return routes.dashboard.bsdas.review;
+    case BsdType.Bsff:
+      return routes.dashboard.bsffs.review;
     case BsdType.Bsdasri:
       return routes.dashboard.bsdasris.review;
     default:

--- a/front/src/Apps/common/queries/reviews/BsffReviewQuery.ts
+++ b/front/src/Apps/common/queries/reviews/BsffReviewQuery.ts
@@ -1,0 +1,194 @@
+import { gql } from "@apollo/client";
+import { companyFragment } from "../fragments";
+
+const reviewFragment = gql`
+  fragment BsffRevisionRequestFragment on BsffRevisionRequest {
+    id
+    createdAt
+    bsff {
+      id
+      status
+      updatedAt
+      type
+      emitter {
+        company {
+          name
+          siret
+          orgId
+        }
+        pickupSite {
+          name
+          address
+          city
+          postalCode
+          infos
+        }
+      }
+      worker {
+        company {
+          name
+          orgId
+        }
+      }
+      ecoOrganisme {
+        siret
+        name
+      }
+      waste {
+        code
+        familyCode
+        materialName
+        pop
+        sealNumbers
+      }
+      weight {
+        value
+      }
+      transporter {
+        company {
+          name
+          siret
+          orgId
+        }
+      }
+      packagings {
+        other
+        quantity
+        type
+        volume
+        identificationNumbers
+      }
+      broker {
+        company {
+          ...CompanyFragment
+        }
+        recepisse {
+          number
+          department
+          validityLimit
+        }
+      }
+      destination {
+        cap
+        company {
+          name
+          siret
+          orgId
+        }
+        reception {
+          weight
+          refusedWeight
+        }
+        operation {
+          code
+          mode
+          description
+        }
+      }
+    }
+    authoringCompany {
+      siret
+      orgId
+      name
+    }
+    approvals {
+      approverSiret
+      status
+    }
+    content {
+      emitter {
+        pickupSite {
+          name
+          address
+          city
+          postalCode
+          infos
+        }
+      }
+      waste {
+        code
+        familyCode
+        materialName
+        pop
+        sealNumbers
+      }
+      packagings {
+        other
+        quantity
+        type
+        volume
+        identificationNumbers
+      }
+      broker {
+        company {
+          ...CompanyFragment
+        }
+        recepisse {
+          number
+          department
+          validityLimit
+        }
+      }
+      destination {
+        cap
+        reception {
+          weight
+          refusedWeight
+        }
+        operation {
+          code
+          mode
+          description
+        }
+      }
+      isCanceled
+    }
+    status
+    comment
+  }
+  ${companyFragment}
+`;
+
+export const GET_BSFF_REVISION_REQUESTS = gql`
+  query BsffRevisionRequests(
+    $siret: String!
+    $where: BsffRevisionRequestWhere
+    $after: String
+  ) {
+    bsffRevisionRequests(siret: $siret, where: $where, after: $after) {
+      edges {
+        node {
+          ...BsffRevisionRequestFragment
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+  ${reviewFragment}
+`;
+
+export const CREATE_BSFF_REVISION_REQUEST = gql`
+  mutation CreateBsffRevisionRequest($input: CreateBsffRevisionRequestInput!) {
+    createBsffRevisionRequest(input: $input) {
+      id
+    }
+  }
+`;
+
+export const CANCEL_BSFF_REVISION_REQUEST = gql`
+  mutation CancelBsffRevisionRequest($id: ID!) {
+    cancelBsffRevisionRequest(id: $id)
+  }
+`;
+
+export const SUBMIT_BSFF_REVISION_REQUEST_APPROVAL = gql`
+  mutation SubmitBsffRevisionRequestApproval($id: ID!, $isApproved: Boolean!) {
+    submitBsffRevisionRequestApproval(id: $id, isApproved: $isApproved) {
+      id
+      status
+    }
+  }
+`;

--- a/front/src/Apps/routes.ts
+++ b/front/src/Apps/routes.ts
@@ -76,7 +76,8 @@ const routes = {
     bsffs: {
       create: "/dashboard/:siret/bsffs/create",
       edit: "/dashboard/:siret/bsffs/edit/:id",
-      view: "/dashboard/:siret/bsffs/view/:id"
+      view: "/dashboard/:siret/bsffs/view/:id",
+      review: "/dashboard/:siret/bsffs/review/:id"
     },
     bsdas: {
       create: "/dashboard/:siret/bsdas/create",
@@ -229,6 +230,7 @@ export const titles = {
   "/dashboard/:siret/bsffs/create": "Créer un BSFF — Trackdéchets",
   "/dashboard/:siret/bsffs/edit/:id": "Modifier le BSFF — Trackdéchets",
   "/dashboard/:siret/bsffs/view/:id": "Aperçu du BSFF — Trackdéchets",
+  "/dashboard/:siret/bsffs/review/:id": "Réviser le BSFF — Trackdéchets",
   "/dashboard/:siret/bsdas/create": "Créer un BSDA — Trackdéchets",
   "/dashboard/:siret/bsdas/edit/:id": "Modifier le BSDA — Trackdéchets",
   "/dashboard/:siret/bsdas/view/:id": "Aperçu du BSDA — Trackdéchets",


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB