### PR TITLE
hotfix/tra-18314 : Erreur code commune introuvable

### DIFF
--- a/back/src/companies/geo/getCodeCommune.ts
+++ b/back/src/companies/geo/getCodeCommune.ts
@@ -3,7 +3,8 @@ import { logger } from "@td/logger";
 import { removeSpecialCharsExceptHyphens } from "../../utils";
 
 // https://adresse.data.gouv.fr/api-doc/adresse
-export const ADRESSE_DATA_GOUV_FR_URL = "https://api-adresse.data.gouv.fr";
+// Ancienne url décomissionnée : https://api-adresse.data.gouv.fr
+export const ADRESSE_DATA_GOUV_FR_URL = "https://data.geopf.fr/geocodage";
 
 interface Properties {
   label?: string;


### PR DESCRIPTION
# Contexte

Mise à jour de l'adresse de l'API de récupération des codes communes suite à la décommission de l'ancienne url.

# Ticket Favro

[TRA-18314](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-18314)
