### PR TITLE
Hotfix/tra-18273 et tra-18314

### DIFF
--- a/back/src/bsffs/validation/bsff/transformers.ts
+++ b/back/src/bsffs/validation/bsff/transformers.ts
@@ -44,18 +44,21 @@ export const checkAndSetPreviousPackagings: ZodBsffTransformer = async (
   ) {
     return {
       ...rest,
-      packagings: previousPackagings.map(p => ({
-        // Reprend les informations de base des contenants en cas de
-        // groupement ou de rééxpedition
-        type: p.type,
-        other: p.other,
-        numero: p.numero,
-        emissionNumero: p.numero,
-        volume: p.volume,
-        weight: p.acceptationWeight ?? 0,
-        operationNoTraceability: false,
-        previousPackagings: [p.id]
-      }))
+      packagings: previousPackagings.map(p => {
+        const userPackaging = bsff.packagings?.find(
+          up => up.numero === p.numero
+        );
+        return {
+          type: p.type,
+          other: p.other,
+          numero: p.numero,
+          emissionNumero: p.numero,
+          volume: userPackaging?.volume ?? p.volume,
+          weight: p.acceptationWeight ?? 0,
+          operationNoTraceability: false,
+          previousPackagings: [p.id]
+        };
+      })
     };
   } else if (bsff.type === BsffType.RECONDITIONNEMENT) {
     return {

--- a/back/src/companies/geo/getCodeCommune.ts
+++ b/back/src/companies/geo/getCodeCommune.ts
@@ -3,7 +3,8 @@ import { logger } from "@td/logger";
 import { removeSpecialCharsExceptHyphens } from "../../utils";
 
 // https://adresse.data.gouv.fr/api-doc/adresse
-export const ADRESSE_DATA_GOUV_FR_URL = "https://api-adresse.data.gouv.fr";
+// Ancienne url décomissionnée : https://api-adresse.data.gouv.fr
+export const ADRESSE_DATA_GOUV_FR_URL = "https://data.geopf.fr/geocodage";
 
 interface Properties {
   label?: string;

--- a/front/src/Apps/Dashboard/Creation/bsff/FormSteps.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsff/FormSteps.tsx
@@ -428,10 +428,6 @@ const BsffFormSteps = ({
     type: BsffType,
     packagings: any[] | null | undefined
   ) {
-    if ([BsffType.Groupement, BsffType.Reexpedition].includes(type)) {
-      return undefined;
-    }
-
     return packagings?.map(p => ({
       type: p.type,
       numero: p.numero,

--- a/front/src/Apps/Dashboard/Creation/bsff/components/BsffPackagingForm.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsff/components/BsffPackagingForm.tsx
@@ -41,6 +41,7 @@ export type PackagingFormProps = {
   touched?: Partial<
     Record<keyof (PackagingInfoInput | BsffPackagingInput), boolean>
   >;
+  volumeEditable?: boolean;
 };
 
 /**
@@ -53,6 +54,8 @@ function BsffPackagingForm({
   packagingTypes,
   inputProps,
   disabled = false,
+  volumeEditable = false, // ← ajouter
+
   errors,
   touched
 }: PackagingFormProps) {
@@ -101,7 +104,7 @@ function BsffPackagingForm({
           <NonScrollableInput
             label={`Volume en litres`}
             className="fr-mb-2w"
-            disabled={disabled}
+            disabled={disabled && !volumeEditable}
             state={errors?.volume && touched?.volume ? "error" : "default"}
             stateRelatedMessage={errors?.volume}
             nativeInputProps={{

--- a/front/src/Apps/Dashboard/Creation/bsff/components/BsffPackagingList.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsff/components/BsffPackagingList.tsx
@@ -13,6 +13,7 @@ export interface RenderPackagingFormProps
   extends Omit<PackagingFormProps, "inputProps" | "errors" | "touched"> {
   fieldName: string;
   idx: number;
+  volumeEditable?: boolean;
 }
 
 export type PackagingListProps = {
@@ -20,6 +21,7 @@ export type PackagingListProps = {
   packagingTypes: (Packagings | BsffPackagingType)[];
   packagingInfos: PackagingInfoInput[];
   disabled?: boolean;
+  volumeEditable?: boolean;
   push: (packaging: PackagingInfoInput) => void;
   remove: (idx: number) => void;
   onRemoveFromTable?: (id: string) => void;
@@ -34,6 +36,8 @@ function BsffPackagingList({
   remove,
   onRemoveFromTable,
   disabled = false,
+  volumeEditable = false,
+
   children
 }: PackagingListProps) {
   const bsffType = useWatch({ name: "type" });
@@ -88,7 +92,8 @@ function BsffPackagingList({
               packagingsLength: packagingInfos.length,
               idx,
               packaging: p,
-              disabled
+              disabled,
+              volumeEditable
             })}
 
             {fromTable

--- a/front/src/Apps/Dashboard/Creation/bsff/components/BsffSelectableWasteTableWrapper.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsff/components/BsffSelectableWasteTableWrapper.tsx
@@ -169,24 +169,30 @@ function BsffSelectableWasteTableWrapper({
     const first = grouping?.[0];
 
     setValue("waste.code", first?.acceptation?.wasteCode ?? first?.waste?.code);
-
     setValue(
       "weight.value",
-      grouping.reduce(
-        (sum, g) => sum + (g.acceptation?.weight ?? g.acceptation?.weight ?? 0),
-        0
-      )
+      grouping.reduce((sum, g) => sum + (g.acceptation?.weight ?? 0), 0)
     );
 
+    const currentPackagings: any[] = getValues("packagings") ?? [];
+
     const allPackagings = grouping.flatMap(g => {
+      const existing = currentPackagings.find(
+        (c: any) => c.id === (g as any).id
+      );
+
       if (g.packagings?.length) {
-        return g.packagings;
+        return g.packagings.map(p => {
+          const ex = currentPackagings.find((c: any) => c.id === (p as any).id);
+          return { ...p, volume: ex?.volume ?? p.volume };
+        });
       }
 
       return [
         {
+          id: (g as any).id,
           type: g.type ?? null,
-          volume: g.volume ?? 0,
+          volume: existing?.volume ?? (g as any).volume ?? 0,
           numero: g.numero ?? "",
           weight: g.acceptation?.weight ?? 0,
           other: g.other ?? null
@@ -198,9 +204,9 @@ function BsffSelectableWasteTableWrapper({
 
     const nextCompany =
       first?.nextBsff?.emitter?.company ?? getInitialCompany();
-
     setValue("nextBsff.company", nextCompany);
   }
+
   function mapPackaging(p: ZodBsffGroupingOrForwarding) {
     if (p.packagings?.length) {
       return p.packagings;
@@ -219,21 +225,22 @@ function BsffSelectableWasteTableWrapper({
 
   function onForwardingChange(fwd: ZodBsffGroupingOrForwarding | null) {
     setValue("waste.code", fwd?.acceptation?.wasteCode ?? fwd?.waste?.code);
+    setValue("weight.value", fwd?.acceptation?.weight ?? 0);
 
-    setValue(
-      "weight.value",
-      fwd?.acceptation?.weight ?? fwd?.acceptation?.weight ?? 0
-    );
+    const currentPackagings: any[] = getValues("packagings") ?? [];
 
     const packagings = fwd?.packagings?.length
-      ? fwd.packagings
+      ? fwd.packagings.map(p => {
+          const ex = currentPackagings.find((c: any) => c.id === (p as any).id);
+          return { ...p, volume: ex?.volume ?? p.volume };
+        })
       : fwd
       ? [
           {
             type: fwd.type ?? null,
-            volume: fwd.volume ?? null,
+            volume: currentPackagings[0]?.volume ?? (fwd as any).volume ?? null,
             numero: fwd.numero ?? "",
-            weight: fwd.acceptation?.weight ?? fwd.acceptation?.weight ?? null,
+            weight: fwd.acceptation?.weight ?? null,
             other: fwd.other ?? null
           }
         ]
@@ -242,7 +249,6 @@ function BsffSelectableWasteTableWrapper({
     setValue("packagings", packagings);
 
     const nextCompany = fwd?.nextBsff?.emitter?.company ?? getInitialCompany();
-
     setValue("nextBsff.company", nextCompany);
   }
   if (error) {

--- a/front/src/Apps/Dashboard/Creation/bsff/components/RhfBsffPackagingForm.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsff/components/RhfBsffPackagingForm.tsx
@@ -13,8 +13,9 @@ function RhfBsffPackagingForm({
   packagingsLength,
   packagingTypes,
   idx,
-  disabled = false
-}: RenderPackagingFormProps) {
+  disabled = false,
+  volumeEditable = false
+}: RenderPackagingFormProps & { volumeEditable?: boolean }) {
   const fieldPath = (name: string) => `${fieldName}.${idx}.${name}`;
 
   const { register, getFieldState, formState, setValue, resetField } =
@@ -66,6 +67,7 @@ function RhfBsffPackagingForm({
       packaging={packaging}
       packagingsLength={packagingsLength}
       packagingTypes={packagingTypes}
+      volumeEditable={volumeEditable}
       disabled={disabled}
       errors={errors}
       touched={touched}
@@ -90,7 +92,8 @@ function RhfBsffPackagingForm({
           })
         },
         volume: {
-          ...register(fieldPath("volume"))
+          ...register(fieldPath("volume")),
+          disabled: volumeEditable ? false : disabled
         },
         weight: {
           ...register(fieldPath("weight"))

--- a/front/src/Apps/Dashboard/Creation/bsff/components/RhfBsffPackagingList.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsff/components/RhfBsffPackagingList.tsx
@@ -7,8 +7,11 @@ import RhfBsffPackagingForm from "./RhfBsffPackagingForm";
 function RhfBsffPackagingList({
   fieldName,
   packagingTypes,
-  disabled = false
-}: Pick<PackagingListProps, "fieldName" | "packagingTypes" | "disabled">) {
+  disabled = false,
+  volumeEditable = false
+}: Pick<PackagingListProps, "fieldName" | "packagingTypes" | "disabled"> & {
+  volumeEditable?: boolean;
+}) {
   const { control, watch, setValue, getValues } = useFormContext(); // ← getValues
   const { append, remove } = useFieldArray({ control, name: fieldName });
 
@@ -52,6 +55,7 @@ function RhfBsffPackagingList({
       packagingInfos={packagings}
       packagingTypes={packagingTypes}
       fieldName={fieldName}
+      volumeEditable={volumeEditable} // ← à transmettre
       push={append}
       remove={remove}
       disabled={disabled}

--- a/front/src/Apps/Dashboard/Creation/bsff/steps/Waste.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsff/steps/Waste.tsx
@@ -216,7 +216,10 @@ const WasteBsff = () => {
                 sealedFields.includes("packagings") ||
                 bsffType === BsffType.Groupement ||
                 bsffType === BsffType.Reexpedition
-                // ← Reconditionnement : pas disabled, modifiable manuellement
+              }
+              volumeEditable={
+                bsffType === BsffType.Groupement ||
+                bsffType === BsffType.Reexpedition
               }
               fieldName="packagings"
               packagingTypes={bsffPackagingTypes}


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Possibilité de modifier le conditionnement sur le BSFF de reconditionnement, regroupement et réexpédition. 
Mise à jour de l'adresse de l'API de récupération des codes communes suite à la décommission de l'ancienne url.


# Ticket Favro

[TRA-18273](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-18273)
[TRA-18314](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-18314)