### PR TITLE
feat(bsdd): add updatedBefore parameter to the forms query

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# Next release
+
+#### :nail_care: Améliorations
+
+- BSDD : Ajouter le paramètre `updatedBefore` sur la requête `forms` pour permettre le filtrage par fenêtre temporelle
+
 # [2026.05.1] 05/05/2026
 
 #### :nail_care: Améliorations

--- a/back/src/forms/resolvers/queries/__tests__/forms.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/forms.integration.ts
@@ -705,6 +705,91 @@ describe("Query.forms", () => {
     expect(updatedAfterTomorrow.forms.length).toBe(0);
   });
 
+  it("should filter by updatedBefore", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    await createForms(user.id, [
+      {
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret,
+        recipientsSirets: [company.siret!]
+      },
+      {
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret,
+        recipientsSirets: [company.siret!]
+      }
+    ]);
+
+    const tomorrow = format(addDays(new Date(), 1), "yyyy-MM-dd");
+    const yesterday = format(subDays(new Date(), 1), "yyyy-MM-dd");
+
+    const { query } = makeClient(user);
+    const { data: updatedBeforeTomorrow } = await query<Pick<Query, "forms">>(
+      `query {
+          forms(updatedBefore: "${tomorrow}") {
+            id
+            recipient {
+              company { siret }
+            }
+          }
+        }
+      `
+    );
+
+    expect(updatedBeforeTomorrow.forms.length).toBe(2);
+
+    const { data: updatedBeforeYesterday } = await query<Pick<Query, "forms">>(
+      `query {
+          forms(updatedBefore: "${yesterday}") {
+            id
+            recipient {
+              company { siret }
+            }
+          }
+        }
+      `
+    );
+
+    expect(updatedBeforeYesterday.forms.length).toBe(0);
+  });
+
+  it("should filter by updatedAfter and updatedBefore", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    await createForms(user.id, [
+      {
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret,
+        recipientsSirets: [company.siret!]
+      }
+    ]);
+
+    const tomorrow = format(addDays(new Date(), 1), "yyyy-MM-dd");
+    const yesterday = format(subDays(new Date(), 1), "yyyy-MM-dd");
+
+    const { query } = makeClient(user);
+    const { data: inRange } = await query<Pick<Query, "forms">>(
+      `query {
+          forms(updatedAfter: "${yesterday}", updatedBefore: "${tomorrow}") {
+            id
+          }
+        }
+      `
+    );
+
+    expect(inRange.forms.length).toBe(1);
+
+    const { data: outOfRange } = await query<Pick<Query, "forms">>(
+      `query {
+          forms(updatedAfter: "${tomorrow}", updatedBefore: "${tomorrow}") {
+            id
+          }
+        }
+      `
+    );
+
+    expect(outOfRange.forms.length).toBe(0);
+  });
+
   it("should filter by waste code", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     await createForms(user.id, [

--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -55,8 +55,11 @@ const formsResolver: QueryResolvers["forms"] = async (_, args, context) => {
     ...paginationArgs,
     orderBy: { rowNumber: "desc" },
     where: {
-      ...(rest.updatedAfter && {
-        updatedAt: { gte: new Date(rest.updatedAfter) }
+      ...((rest.updatedAfter || rest.updatedBefore) && {
+        updatedAt: {
+          ...(rest.updatedAfter && { gte: new Date(rest.updatedAfter) }),
+          ...(rest.updatedBefore && { lt: new Date(rest.updatedBefore) })
+        }
       }),
       ...(rest.sentAfter && { sentAt: { gte: new Date(rest.sentAfter) } }),
       ...(rest.wasteCode && { wasteDetailsCode: rest.wasteCode }),

--- a/back/src/forms/typeDefs/bsdd.queries.graphql
+++ b/back/src/forms/typeDefs/bsdd.queries.graphql
@@ -98,6 +98,14 @@ type Query {
     updatedAfter: String
 
     """
+    (Optionnel) Retourne les BSD modifiés avant la date
+    Filtre sur la date de dernière modification
+    Au format ISO 8601
+    Par défaut vide, aucun filtre n'est appliqué
+    """
+    updatedBefore: String
+
+    """
     (Optionnel) Filtre sur les statuts des bordereaux
     Si aucun filtre n'est passé, les bordereaux seront retournés quel que soit leur statut
     Défaut à vide.


### PR DESCRIPTION
## Context

The `forms` query only has `updatedAfter` to filter BSDD by last modification date. Without `updatedBefore`, it is impossible to query over a precise time window, forcing clients to fetch all data from a given date and filter client-side.

## Changes

Adds an optional `updatedBefore: String` parameter to the `forms` query, aligning BSDD with other BSD types (BSDA, BSFF, BSDASRI) which already support this kind of filtering.

```graphql
query {
  forms(
    siret: "12345678901234"
    updatedAfter: "2024-01-01T00:00:00Z"
    updatedBefore: "2024-02-01T00:00:00Z"
    first: 100
  ) {
    id
    updatedAt
  }
}
```

## Files changed

- `back/src/forms/typeDefs/bsdd.queries.graphql` — adds the `updatedBefore` argument
- `back/src/forms/resolvers/queries/forms.ts` — handles it in the Prisma filter (`updatedAt.lt`)
- `back/src/forms/resolvers/queries/__tests__/forms.integration.ts` — integration tests for `updatedBefore` alone and combined with `updatedAfter`

## Test plan

- [ ] `should filter by updatedBefore` — verifies the filter works standalone
- [ ] `should filter by updatedAfter and updatedBefore` — verifies the time window combination

Original feature request: https://forum.trackdechets.beta.gouv.fr