### PR TITLE
feat(TRA-17923): Récupérer son compte via un code de récupération

### DIFF
--- a/back/src/__tests__/recoveryLogin.integration.ts
+++ b/back/src/__tests__/recoveryLogin.integration.ts
@@ -1,0 +1,205 @@
+import supertest from "supertest";
+import { hash } from "bcrypt";
+import { resetDatabase } from "../../integration-tests/helper";
+import { prisma } from "@td/prisma";
+import { app, sess } from "../server";
+import { userFactory } from "./factories";
+import { addSeconds } from "date-fns";
+
+const { UI_HOST } = process.env;
+const request = supertest(app);
+
+const cookieRegExp = new RegExp(
+  `${sess.name}=(.+); Domain=.+; Path=/; Expires=.+; HttpOnly`
+);
+
+async function createUserWithRecoveryCode(
+  plainCode = "ABCDE-FGHIJ",
+  overrides: Record<string, unknown> = {}
+) {
+  const normalized = plainCode.replace(/-/g, "").toUpperCase();
+  const codeHash = await hash(normalized, 10);
+
+  const user = await userFactory({
+    totpSeed: "ABCD",
+    totpActivatedAt: new Date(),
+    ...overrides
+  });
+
+  await prisma.totpRecoveryCode.create({
+    data: { userId: user.id, codeHash }
+  });
+
+  return { user, plainCode };
+}
+
+async function doLogin(email: string) {
+  const login = await request
+    .post("/login")
+    .send(`email=${email}`)
+    .send("password=pass");
+
+  const sessionCookie = login.header["set-cookie"][0];
+  const cookieValue = sessionCookie.match(cookieRegExp)?.[1];
+  return cookieValue!;
+}
+
+describe("POST /recovery-login", () => {
+  afterEach(() => resetDatabase());
+
+  it("redirects to login when there is no preloggedUser session", async () => {
+    const res = await request
+      .post("/recovery-login")
+      .send("recoveryCode=ABCDE-FGHIJ");
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toContain(
+      "errorCode=TOTP_TIMEOUT_OR_MISSING_SESSION"
+    );
+  });
+
+  it("logs the user in with a valid recovery code, revokes TOTP and sets mustReconfigureMfa", async () => {
+    const { user, plainCode } = await createUserWithRecoveryCode();
+    const cookie = await doLogin(user.email);
+
+    const res = await request
+      .post("/recovery-login")
+      .send(`recoveryCode=${plainCode}`)
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    // should redirect to home (user is now connected)
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe(`http://${UI_HOST}/`);
+
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+
+    // TOTP must be revoked
+    expect(updatedUser.totpSeed).toBeNull();
+    expect(updatedUser.totpActivatedAt).toBeNull();
+    // reconfiguration flag must be active
+    expect(updatedUser.mustReconfigureMfa).toBe(true);
+    // recovery counters must be reset
+    expect(updatedUser.recoveryFails).toBe(0);
+    expect(updatedUser.recoveryLockedUntil).toBeNull();
+
+    // all recovery codes must be deleted
+    const remainingCodes = await prisma.totpRecoveryCode.findMany({
+      where: { userId: user.id }
+    });
+    expect(remainingCodes).toHaveLength(0);
+  });
+
+  it("is case-insensitive and ignores dashes", async () => {
+    const { user } = await createUserWithRecoveryCode("ABCDE-FGHIJ");
+    const cookie = await doLogin(user.email);
+
+    // Submit the code in lowercase without dashes
+    const res = await request
+      .post("/recovery-login")
+      .send("recoveryCode=abcdefghij")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe(`http://${UI_HOST}/`);
+  });
+
+  it("returns INVALID_RECOVERY_CODE for a wrong code (fail 1 of 3, no lockout)", async () => {
+    const { user } = await createUserWithRecoveryCode();
+    const cookie = await doLogin(user.email);
+
+    const res = await request
+      .post("/recovery-login")
+      .send("recoveryCode=WRONG-CODE")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toContain("errorCode=INVALID_RECOVERY_CODE");
+    expect(res.header.location).not.toContain("RECOVERY_LOCKOUT");
+
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    expect(updatedUser.recoveryFails).toBe(1);
+    expect(updatedUser.recoveryLockedUntil).toBeNull();
+  });
+
+  it("triggers lockout on 3rd consecutive invalid code", async () => {
+    const { user } = await createUserWithRecoveryCode("ABCDE-FGHIJ", {
+      recoveryFails: 2
+    });
+    const cookie = await doLogin(user.email);
+    const before = new Date();
+
+    const res = await request
+      .post("/recovery-login")
+      .send("recoveryCode=WRONG-CODE")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toContain("errorCode=RECOVERY_LOCKOUT");
+    expect(res.header.location).toContain("lockout=");
+
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    expect(updatedUser.recoveryFails).toBe(3);
+    expect(updatedUser.recoveryLockedUntil).not.toBeNull();
+    // lockout must be ~5 minutes from now
+    expect(
+      updatedUser.recoveryLockedUntil!.getTime() - before.getTime() >= 300_000
+    ).toBe(true);
+  });
+
+  it("blocks any attempt during an active lockout", async () => {
+    const recoveryLockedUntil = addSeconds(new Date(), 30);
+    const { user, plainCode } = await createUserWithRecoveryCode(
+      "ABCDE-FGHIJ",
+      {
+        recoveryFails: 3,
+        recoveryLockedUntil
+      }
+    );
+    const cookie = await doLogin(user.email);
+
+    // Even the correct code must be rejected
+    const res = await request
+      .post("/recovery-login")
+      .send(`recoveryCode=${plainCode}`)
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toContain("errorCode=RECOVERY_LOCKOUT");
+
+    // User must not be logged in and TOTP must remain intact
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    expect(updatedUser.totpSeed).not.toBeNull();
+    expect(updatedUser.mustReconfigureMfa).toBe(false);
+  });
+
+  it("rejects a code that has already been deleted (already used)", async () => {
+    const { user } = await createUserWithRecoveryCode("ABCDE-FGHIJ");
+    const cookie = await doLogin(user.email);
+
+    // First use — valid
+    await request
+      .post("/recovery-login")
+      .send("recoveryCode=ABCDE-FGHIJ")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    // Re-login to get a new preloggedUser session
+    const cookie2 = await doLogin(user.email);
+
+    // Second use of the same code — must fail (codes were deleted)
+    const res = await request
+      .post("/recovery-login")
+      .send("recoveryCode=ABCDE-FGHIJ")
+      .set("Cookie", `${sess.name}=${cookie2}`);
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toContain("errorCode=INVALID_RECOVERY_CODE");
+  });
+});

--- a/back/src/__tests__/recoveryLogin.integration.ts
+++ b/back/src/__tests__/recoveryLogin.integration.ts
@@ -180,6 +180,25 @@ describe("POST /recovery-login", () => {
     expect(updatedUser.mustReconfigureMfa).toBe(false);
   });
 
+  it("regenerates the session on successful recovery login (prevents session fixation)", async () => {
+    const { user, plainCode } = await createUserWithRecoveryCode();
+    const cookie = await doLogin(user.email);
+
+    const res = await request
+      .post("/recovery-login")
+      .send(`recoveryCode=${plainCode}`)
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.status).toBe(302);
+
+    // A new Set-Cookie header must be present with a different session ID
+    const newCookieHeader = res.header["set-cookie"]?.[0];
+    expect(newCookieHeader).toBeDefined();
+    const newCookieValue = newCookieHeader?.match(cookieRegExp)?.[1];
+    expect(newCookieValue).toBeDefined();
+    expect(newCookieValue).not.toBe(cookie);
+  });
+
   it("rejects a code that has already been deleted (already used)", async () => {
     const { user } = await createUserWithRecoveryCode("ABCDE-FGHIJ");
     const cookie = await doLogin(user.email);

--- a/back/src/__tests__/recoveryLogin.integration.ts
+++ b/back/src/__tests__/recoveryLogin.integration.ts
@@ -203,20 +203,13 @@ describe("POST /recovery-login", () => {
     const { user } = await createUserWithRecoveryCode("ABCDE-FGHIJ");
     const cookie = await doLogin(user.email);
 
-    // First use — valid
-    await request
-      .post("/recovery-login")
-      .send("recoveryCode=ABCDE-FGHIJ")
-      .set("Cookie", `${sess.name}=${cookie}`);
+    // Simulate an already-consumed code by deleting it directly from DB
+    await prisma.totpRecoveryCode.deleteMany({ where: { userId: user.id } });
 
-    // Re-login to get a new preloggedUser session
-    const cookie2 = await doLogin(user.email);
-
-    // Second use of the same code — must fail (codes were deleted)
     const res = await request
       .post("/recovery-login")
       .send("recoveryCode=ABCDE-FGHIJ")
-      .set("Cookie", `${sess.name}=${cookie2}`);
+      .set("Cookie", `${sess.name}=${cookie}`);
 
     expect(res.status).toBe(302);
     expect(res.header.location).toContain("errorCode=INVALID_RECOVERY_CODE");

--- a/back/src/__tests__/recoveryLogin.integration.ts
+++ b/back/src/__tests__/recoveryLogin.integration.ts
@@ -5,6 +5,10 @@ import { prisma } from "@td/prisma";
 import { app, sess } from "../server";
 import { userFactory } from "./factories";
 import { addSeconds } from "date-fns";
+import { sendMail } from "../mailer/mailing";
+
+jest.mock("../mailer/mailing");
+(sendMail as jest.Mock).mockImplementation(() => Promise.resolve());
 
 const { UI_HOST } = process.env;
 const request = supertest(app);
@@ -45,7 +49,10 @@ async function doLogin(email: string) {
 }
 
 describe("POST /recovery-login", () => {
-  afterEach(() => resetDatabase());
+  afterEach(async () => {
+    await resetDatabase();
+    (sendMail as jest.Mock).mockClear();
+  });
 
   it("redirects to login when there is no preloggedUser session", async () => {
     const res = await request
@@ -89,6 +96,18 @@ describe("POST /recovery-login", () => {
       where: { userId: user.id }
     });
     expect(remainingCodes).toHaveLength(0);
+  });
+
+  it("n'envoie aucun email lors de la validation du code de récupération", async () => {
+    const { user, plainCode } = await createUserWithRecoveryCode();
+    const cookie = await doLogin(user.email);
+
+    await request
+      .post("/recovery-login")
+      .send(`recoveryCode=${plainCode}`)
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(sendMail as jest.Mock).not.toHaveBeenCalled();
   });
 
   it("is case-insensitive and ignores dashes", async () => {

--- a/back/src/auth/recoveryLoginHandler.ts
+++ b/back/src/auth/recoveryLoginHandler.ts
@@ -136,13 +136,17 @@ export async function recoveryLoginHandler(
       })
     ).catch(() => undefined);
 
-    // Connexion de l'utilisateur — le frontend détectera mustReconfigureMfa via `me`
-    req.logIn(user, err => {
-      if (err) {
-        return next(err);
+    req.session.regenerate(regenerateErr => {
+      if (regenerateErr) {
+        return next(regenerateErr);
       }
-      req.session.issuedAt = new Date().toISOString();
-      res.redirect(`${UI_BASE_URL}${returnTo}`);
+      req.logIn(user, loginErr => {
+        if (loginErr) {
+          return next(loginErr);
+        }
+        req.session.issuedAt = new Date().toISOString();
+        res.redirect(`${UI_BASE_URL}${returnTo}`);
+      });
     });
   } catch (err) {
     next(err);

--- a/back/src/auth/recoveryLoginHandler.ts
+++ b/back/src/auth/recoveryLoginHandler.ts
@@ -1,0 +1,150 @@
+import { Request, Response, NextFunction } from "express";
+import { prisma, User } from "@td/prisma";
+import { addSeconds } from "date-fns";
+import { sanitizeEmail, getUIBaseURL } from "../utils";
+import { getSafeReturnTo } from "../common/helpers";
+import { findValidRecoveryCode } from "../users/services/recoveryCode.service";
+import { sendMail } from "../mailer/mailing";
+import { onTotpRecovery, renderMail } from "@td/mail";
+
+const UI_BASE_URL = getUIBaseURL();
+const RECOVERY_MAX_FAILS = 3;
+const RECOVERY_LOCK_SECONDS = 300; // 5 minutes, cohérent avec le lockout TOTP
+
+async function increaseRecoveryLock(
+  user: User
+): Promise<{ recoveryFails: number; recoveryLockedUntil: Date | null }> {
+  const recoveryFails = user.recoveryFails + 1;
+  const recoveryLockedUntil =
+    recoveryFails >= RECOVERY_MAX_FAILS
+      ? addSeconds(new Date(), RECOVERY_LOCK_SECONDS)
+      : null;
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { recoveryFails, recoveryLockedUntil }
+  });
+  return { recoveryFails, recoveryLockedUntil };
+}
+
+/**
+ * Handler POST /recovery-login
+ *
+ * Valide un code de récupération soumis depuis la modale "Je n'ai pas accès à
+ * l'application". Requiert une session preloggedUser valide (même prérequis que /otp).
+ *
+ * En cas de succès :
+ *  - tous les codes de récupération de l'utilisateur sont invalidés
+ *  - le secret TOTP est révoqué
+ *  - mustReconfigureMfa est mis à true
+ *  - l'utilisateur est connecté
+ *  - un email de notification de sécurité est envoyé
+ *
+ * Lockout : RECOVERY_MAX_FAILS (3) tentatives invalides → blocage RECOVERY_LOCK_SECONDS (300s)
+ */
+export async function recoveryLoginHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const { recoveryCode } = req.body;
+    const returnTo = getSafeReturnTo(req.body.returnTo, UI_BASE_URL);
+
+    const userEmail = req.session?.preloggedUser?.userEmail;
+    const expire = req.session?.preloggedUser?.expire;
+
+    // Session preloggedUser absente ou expirée
+    if (!userEmail || !expire || new Date(expire) < new Date()) {
+      delete req.session?.preloggedUser;
+      res.redirect(
+        `${UI_BASE_URL}/login?errorCode=TOTP_TIMEOUT_OR_MISSING_SESSION`
+      );
+      return;
+    }
+
+    if (!recoveryCode || typeof recoveryCode !== "string") {
+      res.redirect(
+        `${UI_BASE_URL}/second-factor?errorCode=MISSING_RECOVERY_CODE`
+      );
+      return;
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { email: sanitizeEmail(userEmail) }
+    });
+
+    if (!user) {
+      res.redirect(
+        `${UI_BASE_URL}/login?errorCode=TOTP_TIMEOUT_OR_MISSING_SESSION`
+      );
+      return;
+    }
+
+    // Blocage actif
+    if (user.recoveryLockedUntil && user.recoveryLockedUntil > new Date()) {
+      const lockout = user.recoveryLockedUntil.getTime();
+      res.redirect(
+        `${UI_BASE_URL}/second-factor?errorCode=RECOVERY_LOCKOUT&lockout=${lockout}`
+      );
+      return;
+    }
+
+    // Validation du code de récupération
+    const recoveryCodeId = await findValidRecoveryCode(user.id, recoveryCode);
+
+    if (!recoveryCodeId) {
+      const { recoveryFails, recoveryLockedUntil } = await increaseRecoveryLock(
+        user
+      );
+
+      if (recoveryFails >= RECOVERY_MAX_FAILS) {
+        res.redirect(
+          `${UI_BASE_URL}/second-factor?errorCode=RECOVERY_LOCKOUT&lockout=${recoveryLockedUntil!.getTime()}`
+        );
+      } else {
+        res.redirect(
+          `${UI_BASE_URL}/second-factor?errorCode=INVALID_RECOVERY_CODE`
+        );
+      }
+      return;
+    }
+
+    // Code valide : révocation complète TOTP + activation flag reconfiguration
+    await prisma.$transaction([
+      // Invalide tous les codes (y compris le code utilisé — pas d'audit trail nécessaire)
+      prisma.totpRecoveryCode.deleteMany({ where: { userId: user.id } }),
+      // Révoque le TOTP, remet les compteurs à zéro, active la reconfiguration forcée
+      prisma.user.update({
+        where: { id: user.id },
+        data: {
+          totpSeed: null,
+          totpActivatedAt: null,
+          totpFails: 0,
+          totpLockedUntil: null,
+          recoveryFails: 0,
+          recoveryLockedUntil: null,
+          mustReconfigureMfa: true
+        }
+      })
+    ]);
+
+    // Email de notification (non bloquant)
+    sendMail(
+      renderMail(onTotpRecovery, {
+        to: [{ name: user.name, email: user.email }],
+        variables: { name: user.name }
+      })
+    ).catch(() => undefined);
+
+    // Connexion de l'utilisateur — le frontend détectera mustReconfigureMfa via `me`
+    req.logIn(user, err => {
+      if (err) {
+        return next(err);
+      }
+      req.session.issuedAt = new Date().toISOString();
+      res.redirect(`${UI_BASE_URL}${returnTo}`);
+    });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/back/src/auth/recoveryLoginHandler.ts
+++ b/back/src/auth/recoveryLoginHandler.ts
@@ -6,6 +6,7 @@ import { getSafeReturnTo } from "../common/helpers";
 import { findValidRecoveryCode } from "../users/services/recoveryCode.service";
 import { sendMail } from "../mailer/mailing";
 import { onTotpRecovery, renderMail } from "@td/mail";
+import { AuthType } from "./auth";
 
 const UI_BASE_URL = getUIBaseURL();
 const RECOVERY_MAX_FAILS = 3;
@@ -140,7 +141,7 @@ export async function recoveryLoginHandler(
       if (regenerateErr) {
         return next(regenerateErr);
       }
-      req.logIn(user, loginErr => {
+      req.logIn({ ...user, auth: AuthType.Session }, loginErr => {
         if (loginErr) {
           return next(loginErr);
         }

--- a/back/src/auth/recoveryLoginHandler.ts
+++ b/back/src/auth/recoveryLoginHandler.ts
@@ -4,8 +4,6 @@ import { addSeconds } from "date-fns";
 import { sanitizeEmail, getUIBaseURL } from "../utils";
 import { getSafeReturnTo } from "../common/helpers";
 import { findValidRecoveryCode } from "../users/services/recoveryCode.service";
-import { sendMail } from "../mailer/mailing";
-import { onTotpRecovery, renderMail } from "@td/mail";
 import { AuthType } from "./auth";
 
 const UI_BASE_URL = getUIBaseURL();
@@ -38,7 +36,7 @@ async function increaseRecoveryLock(
  *  - le secret TOTP est révoqué
  *  - mustReconfigureMfa est mis à true
  *  - l'utilisateur est connecté
- *  - un email de notification de sécurité est envoyé
+ *  - l'email de récupération est envoyé en fin de reconfiguration (finalizeMfaSetup)
  *
  * Lockout : RECOVERY_MAX_FAILS (3) tentatives invalides → blocage RECOVERY_LOCK_SECONDS (300s)
  */
@@ -128,14 +126,6 @@ export async function recoveryLoginHandler(
         }
       })
     ]);
-
-    // Email de notification (non bloquant)
-    sendMail(
-      renderMail(onTotpRecovery, {
-        to: [{ name: user.name, email: user.email }],
-        variables: { name: user.name }
-      })
-    ).catch(() => undefined);
 
     req.session.regenerate(regenerateErr => {
       if (regenerateErr) {

--- a/back/src/common/typeDefs/common.objects.graphql
+++ b/back/src/common/typeDefs/common.objects.graphql
@@ -49,4 +49,7 @@ type User {
 
   "Indique si l'authentification TOTP est activée sur le compte"
   totpEnabled: Boolean!
+
+  "Indique si l'utilisateur doit reconfigurer sa MFA avant d'accéder à la plateforme"
+  mustReconfigureMfa: Boolean!
 }

--- a/back/src/routers/auth-router.ts
+++ b/back/src/routers/auth-router.ts
@@ -7,6 +7,7 @@ import nocache from "../common/middlewares/nocache";
 import { rateLimiterMiddleware } from "../common/middlewares/rateLimiter";
 import { getUIBaseURL, sanitizeEmail } from "../utils";
 import { getSafeReturnTo } from "../common/helpers";
+import { recoveryLoginHandler } from "../auth/recoveryLoginHandler";
 
 const UI_BASE_URL = getUIBaseURL();
 
@@ -92,6 +93,19 @@ authRouter.post("/otp", (req, res, next) => {
     });
   })(req, res, next);
 });
+
+authRouter.post(
+  "/recovery-login",
+  rateLimiterMiddleware({
+    windowMs,
+    maxRequestsPerWindow,
+    keyGenerator: (ip, request) => {
+      const userEmail = request.session?.preloggedUser?.userEmail;
+      return `recovery_login_${ip}_${userEmail ?? "void"}`;
+    }
+  }),
+  recoveryLoginHandler
+);
 
 authRouter.get("/isAuthenticated", nocache, (req, res) => {
   return res.json({ isAuthenticated: req.isAuthenticated() });

--- a/back/src/users/resolvers/Mutation.ts
+++ b/back/src/users/resolvers/Mutation.ts
@@ -4,6 +4,7 @@ import changePassword from "./mutations/changePassword";
 import generateTotpSetup from "./mutations/generateTotpSetup";
 import confirmTotpSetup from "./mutations/confirmTotpSetup";
 import disableTotp from "./mutations/disableTotp";
+import completeMfaReconfiguration from "./mutations/completeMfaReconfiguration";
 import createPasswordResetRequest from "./mutations/createPasswordResetRequest";
 import resendActivationEmail from "./mutations/resendActivationEmail";
 import editProfile from "./mutations/editProfile";
@@ -50,7 +51,8 @@ const Mutation: MutationResolvers = {
   subscribeToNotifications,
   generateTotpSetup,
   confirmTotpSetup,
-  disableTotp
+  disableTotp,
+  completeMfaReconfiguration
 };
 
 export default Mutation;

--- a/back/src/users/resolvers/Mutation.ts
+++ b/back/src/users/resolvers/Mutation.ts
@@ -3,6 +3,7 @@ import signup from "./mutations/signup";
 import changePassword from "./mutations/changePassword";
 import generateTotpSetup from "./mutations/generateTotpSetup";
 import confirmTotpSetup from "./mutations/confirmTotpSetup";
+import finalizeMfaSetup from "./mutations/finalizeMfaSetup";
 import disableTotp from "./mutations/disableTotp";
 import completeMfaReconfiguration from "./mutations/completeMfaReconfiguration";
 import createPasswordResetRequest from "./mutations/createPasswordResetRequest";
@@ -51,6 +52,7 @@ const Mutation: MutationResolvers = {
   subscribeToNotifications,
   generateTotpSetup,
   confirmTotpSetup,
+  finalizeMfaSetup,
   disableTotp,
   completeMfaReconfiguration
 };

--- a/back/src/users/resolvers/mutations/__tests__/finalizeMfaSetup.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/finalizeMfaSetup.integration.ts
@@ -1,0 +1,122 @@
+import { userFactory } from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { prisma } from "@td/prisma";
+import { AuthType } from "../../../../auth/auth";
+import type { Mutation } from "@td/codegen-back";
+import { sendMail } from "../../../../mailer/mailing";
+import { onTotpActivated, onTotpRecovery, renderMail } from "@td/mail";
+
+jest.mock("../../../../mailer/mailing");
+(sendMail as jest.Mock).mockImplementation(() => Promise.resolve());
+
+const FINALIZE_MFA_SETUP = `
+  mutation FinalizeMfaSetup {
+    finalizeMfaSetup
+  }
+`;
+
+async function createUserReadyToFinalize(
+  overrides: Record<string, unknown> = {}
+) {
+  const user = await userFactory({
+    totpSeed: "TESTSEED",
+    totpActivatedAt: null,
+    ...overrides
+  });
+
+  await prisma.totpRecoveryCode.create({
+    data: { userId: user.id, codeHash: "fakehash" }
+  });
+
+  return user;
+}
+
+describe("Mutation.finalizeMfaSetup", () => {
+  afterEach(async () => {
+    await resetDatabase();
+    (sendMail as jest.Mock).mockClear();
+  });
+
+  it("envoie onTotpActivated lors d'une activation MFA classique (mustReconfigureMfa=false)", async () => {
+    const user = await createUserReadyToFinalize({ mustReconfigureMfa: false });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    const { data, errors } = await mutate<Pick<Mutation, "finalizeMfaSetup">>(
+      FINALIZE_MFA_SETUP
+    );
+
+    expect(errors).toBeUndefined();
+    expect(data.finalizeMfaSetup).toBe(true);
+
+    expect(sendMail as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(sendMail as jest.Mock).toHaveBeenCalledWith(
+      renderMail(onTotpActivated, {
+        to: [{ name: user.name, email: user.email }]
+      })
+    );
+    expect(sendMail as jest.Mock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: onTotpRecovery.subject
+      })
+    );
+
+    const dbUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    expect(dbUser.totpActivatedAt).not.toBeNull();
+    expect(dbUser.mustReconfigureMfa).toBe(false);
+  });
+
+  it("envoie onTotpRecovery lors d'une reconfiguration après code de récupération (mustReconfigureMfa=true)", async () => {
+    const user = await createUserReadyToFinalize({ mustReconfigureMfa: true });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    // Précondition : mustReconfigureMfa vaut bien true avant la finalisation
+    const userBeforeFinalize = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    expect(userBeforeFinalize.mustReconfigureMfa).toBe(true);
+
+    const { data, errors } = await mutate<Pick<Mutation, "finalizeMfaSetup">>(
+      FINALIZE_MFA_SETUP
+    );
+
+    expect(errors).toBeUndefined();
+    expect(data.finalizeMfaSetup).toBe(true);
+
+    expect(sendMail as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(sendMail as jest.Mock).toHaveBeenCalledWith(
+      renderMail(onTotpRecovery, {
+        to: [{ name: user.name, email: user.email }],
+        variables: { name: user.name }
+      })
+    );
+    expect(sendMail as jest.Mock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: onTotpActivated.subject
+      })
+    );
+
+    // Après finalizeMfaSetup : TOTP activé, mustReconfigureMfa toujours true
+    // (il sera remis à false par completeMfaReconfiguration)
+    const dbUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    expect(dbUser.totpActivatedAt).not.toBeNull();
+    expect(dbUser.mustReconfigureMfa).toBe(true);
+  });
+
+  it("mustReconfigureMfa est false en base après finalizeMfaSetup quand mustReconfigureMfa valait false", async () => {
+    const user = await createUserReadyToFinalize({ mustReconfigureMfa: false });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    await mutate<Pick<Mutation, "finalizeMfaSetup">>(FINALIZE_MFA_SETUP);
+
+    const dbUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    // mustReconfigureMfa n'est pas touché par finalizeMfaSetup : il reste false
+    expect(dbUser.mustReconfigureMfa).toBe(false);
+  });
+});

--- a/back/src/users/resolvers/mutations/completeMfaReconfiguration.ts
+++ b/back/src/users/resolvers/mutations/completeMfaReconfiguration.ts
@@ -1,0 +1,50 @@
+import { prisma } from "@td/prisma";
+import { applyAuthStrategies, AuthType } from "../../../auth/auth";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import type { MutationResolvers } from "@td/codegen-back";
+import { UserInputError } from "../../../common/errors";
+
+/**
+ * Finalise le parcours de reconfiguration MFA obligatoire.
+ * Appelée après que l'utilisateur a :
+ *  - configuré un nouveau TOTP (confirmTotpSetup)
+ *  - obtenu ses nouveaux codes de récupération
+ *  - confirmé leur sauvegarde
+ * Remet mustReconfigureMfa à false et débloque l'accès à la plateforme.
+ */
+const completeMfaReconfigurationResolver: MutationResolvers["completeMfaReconfiguration"] =
+  async (_, __, context) => {
+    applyAuthStrategies(context, [AuthType.Session]);
+    const user = checkIsAuthenticated(context);
+
+    const dbUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+
+    if (!dbUser.mustReconfigureMfa) {
+      throw new UserInputError(
+        "Aucune reconfiguration MFA n'est en attente pour ce compte."
+      );
+    }
+
+    if (!dbUser.totpSeed || !dbUser.totpActivatedAt) {
+      throw new UserInputError(
+        "Le parcours de reconfiguration MFA n'est pas complet. Configurez d'abord un nouveau second facteur."
+      );
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: dbUser.id },
+      data: { mustReconfigureMfa: false }
+    });
+
+    return {
+      ...updatedUser,
+      companies: [],
+      featureFlags: [],
+      totpEnabled: true,
+      mustReconfigureMfa: false
+    };
+  };
+
+export default completeMfaReconfigurationResolver;

--- a/back/src/users/resolvers/mutations/confirmTotpSetup.ts
+++ b/back/src/users/resolvers/mutations/confirmTotpSetup.ts
@@ -6,8 +6,6 @@ import { applyAuthStrategies, AuthType } from "../../../auth/auth";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import type { MutationResolvers } from "@td/codegen-back";
 import { UserInputError } from "../../../common/errors";
-import { sendMail } from "../../../mailer/mailing";
-import { onTotpActivated, renderMail } from "@td/mail";
 
 const RECOVERY_CODE_COUNT = 10;
 const RECOVERY_CODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -50,9 +48,13 @@ function verifyTotpCode(seed: string, code: string): boolean {
 }
 
 /**
- * Confirme la configuration TOTP en validant le premier code.
- * Active le TOTP, génère les codes de récupération et envoie un e-mail de confirmation.
- * Révoque les sessions actives sur les autres appareils via passwordUpdatedAt.
+ * Valide le code TOTP et génère les codes de récupération.
+ * N'active PAS encore la MFA — l'activation définitive est faite par finalizeMfaSetup
+ * une fois que l'utilisateur a confirmé avoir sauvegardé ses codes.
+ *
+ * État après cet appel : totpSeed set, totpActivatedAt null, TotpRecoveryCodes créés.
+ * Cet état est considéré comme un setup incomplet : il sera nettoyé si l'utilisateur
+ * relance le parcours (generateTotpSetup) sans avoir finalisé.
  */
 const confirmTotpSetupResolver: MutationResolvers["confirmTotpSetup"] = async (
   _,
@@ -95,21 +97,9 @@ const confirmTotpSetupResolver: MutationResolvers["confirmTotpSetup"] = async (
     )
   );
 
-  const now = new Date();
-
+  // Stockage des codes — on remplace tout setup précédent incomplet
   await prisma.$transaction([
-    // Activation du TOTP
-    prisma.user.update({
-      where: { id: dbUser.id },
-      data: {
-        totpActivatedAt: now,
-        // Mise à jour de passwordUpdatedAt pour invalider les sessions des autres appareils
-        passwordUpdatedAt: now
-      }
-    }),
-    // Suppression de tout code de récupération existant
     prisma.totpRecoveryCode.deleteMany({ where: { userId: dbUser.id } }),
-    // Stockage des codes hachés
     ...hashedCodes.map(codeHash =>
       prisma.totpRecoveryCode.create({
         data: { userId: dbUser.id, codeHash }
@@ -117,16 +107,8 @@ const confirmTotpSetupResolver: MutationResolvers["confirmTotpSetup"] = async (
     )
   ]);
 
-  // Mise à jour de issuedAt pour garder la session courante valide
-  context.req.session.issuedAt = new Date().toISOString();
-
-  // E-mail de confirmation
-  await sendMail(
-    renderMail(onTotpActivated, {
-      to: [{ name: dbUser.name, email: dbUser.email }]
-    })
-  );
-
+  // La MFA n'est pas encore activée : totpActivatedAt reste null.
+  // L'activation définitive est déléguée à finalizeMfaSetup.
   return { codes: plainCodes };
 };
 

--- a/back/src/users/resolvers/mutations/disableTotp.ts
+++ b/back/src/users/resolvers/mutations/disableTotp.ts
@@ -1,4 +1,3 @@
-import { compare } from "bcrypt";
 import { TOTP } from "totp-generator";
 import { prisma } from "@td/prisma";
 import { applyAuthStrategies, AuthType } from "../../../auth/auth";
@@ -7,29 +6,13 @@ import type { MutationResolvers } from "@td/codegen-back";
 import { UserInputError } from "../../../common/errors";
 import { sendMail } from "../../../mailer/mailing";
 import { onTotpDisabled, renderMail } from "@td/mail";
+import { findValidRecoveryCode } from "../../services/recoveryCode.service";
 
 function verifyTotpCode(seed: string, code: string): boolean {
   const { otp } = TOTP.generate(seed);
   const thirtySecondsAgo = Date.now() - 30 * 1000;
   const { otp: lastOtp } = TOTP.generate(seed, { timestamp: thirtySecondsAgo });
   return [otp, lastOtp].includes(code);
-}
-
-async function findValidRecoveryCode(
-  userId: string,
-  code: string
-): Promise<string | null> {
-  const normalized = code.replace(/-/g, "").toUpperCase();
-  const recoveryCodes = await prisma.totpRecoveryCode.findMany({
-    where: { userId, usedAt: null }
-  });
-
-  for (const rc of recoveryCodes) {
-    if (await compare(normalized, rc.codeHash)) {
-      return rc.id;
-    }
-  }
-  return null;
 }
 
 /**

--- a/back/src/users/resolvers/mutations/finalizeMfaSetup.ts
+++ b/back/src/users/resolvers/mutations/finalizeMfaSetup.ts
@@ -4,7 +4,7 @@ import { checkIsAuthenticated } from "../../../common/permissions";
 import type { MutationResolvers } from "@td/codegen-back";
 import { UserInputError } from "../../../common/errors";
 import { sendMail } from "../../../mailer/mailing";
-import { onTotpActivated, renderMail } from "@td/mail";
+import { onTotpActivated, onTotpRecovery, renderMail } from "@td/mail";
 
 /**
  * Finalise l'activation MFA après que l'utilisateur a confirmé avoir sauvegardé
@@ -41,6 +41,10 @@ const finalizeMfaSetupResolver: MutationResolvers["finalizeMfaSetup"] = async (
     );
   }
 
+  // Capture avant toute mise à jour : garantit que la valeur n'est pas écrasée
+  // si l'update venait à inclure mustReconfigureMfa dans le futur.
+  const isRecoveryReconfiguration = dbUser.mustReconfigureMfa === true;
+
   const now = new Date();
 
   await prisma.user.update({
@@ -55,11 +59,20 @@ const finalizeMfaSetupResolver: MutationResolvers["finalizeMfaSetup"] = async (
   // Mise à jour de issuedAt pour garder la session courante valide
   context.req.session.issuedAt = new Date().toISOString();
 
-  await sendMail(
-    renderMail(onTotpActivated, {
-      to: [{ name: dbUser.name, email: dbUser.email }]
-    })
-  );
+  if (isRecoveryReconfiguration) {
+    await sendMail(
+      renderMail(onTotpRecovery, {
+        to: [{ name: dbUser.name, email: dbUser.email }],
+        variables: { name: dbUser.name }
+      })
+    );
+  } else {
+    await sendMail(
+      renderMail(onTotpActivated, {
+        to: [{ name: dbUser.name, email: dbUser.email }]
+      })
+    );
+  }
 
   return true;
 };

--- a/back/src/users/resolvers/mutations/finalizeMfaSetup.ts
+++ b/back/src/users/resolvers/mutations/finalizeMfaSetup.ts
@@ -1,0 +1,67 @@
+import { prisma } from "@td/prisma";
+import { applyAuthStrategies, AuthType } from "../../../auth/auth";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import type { MutationResolvers } from "@td/codegen-back";
+import { UserInputError } from "../../../common/errors";
+import { sendMail } from "../../../mailer/mailing";
+import { onTotpActivated, renderMail } from "@td/mail";
+
+/**
+ * Finalise l'activation MFA après que l'utilisateur a confirmé avoir sauvegardé
+ * ses codes de récupération.
+ *
+ * Pré-requis (setup complet) : totpSeed présent, totpActivatedAt null,
+ * et des TotpRecoveryCodes existent (générés par confirmTotpSetup).
+ *
+ * C'est ici que la MFA devient réellement active : totpActivatedAt est posé,
+ * les sessions sur les autres appareils sont révoquées via passwordUpdatedAt.
+ */
+const finalizeMfaSetupResolver: MutationResolvers["finalizeMfaSetup"] = async (
+  _,
+  __,
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  const user = checkIsAuthenticated(context);
+
+  const dbUser = await prisma.user.findUniqueOrThrow({
+    where: { id: user.id },
+    include: { totpRecoveryCodes: { take: 1 } }
+  });
+
+  if (dbUser.totpActivatedAt) {
+    throw new UserInputError("Le TOTP est déjà activé sur ce compte.");
+  }
+
+  // Le setup est considéré complet si confirmTotpSetup a été appelé avec succès :
+  // totpSeed présent + au moins un TotpRecoveryCode créé.
+  if (!dbUser.totpSeed || dbUser.totpRecoveryCodes.length === 0) {
+    throw new UserInputError(
+      "Le parcours de configuration TOTP n'est pas complet. Veuillez valider votre code TOTP d'abord."
+    );
+  }
+
+  const now = new Date();
+
+  await prisma.user.update({
+    where: { id: dbUser.id },
+    data: {
+      totpActivatedAt: now,
+      // Révocation des sessions actives sur les autres appareils
+      passwordUpdatedAt: now
+    }
+  });
+
+  // Mise à jour de issuedAt pour garder la session courante valide
+  context.req.session.issuedAt = new Date().toISOString();
+
+  await sendMail(
+    renderMail(onTotpActivated, {
+      to: [{ name: dbUser.name, email: dbUser.email }]
+    })
+  );
+
+  return true;
+};
+
+export default finalizeMfaSetupResolver;

--- a/back/src/users/resolvers/mutations/generateTotpSetup.ts
+++ b/back/src/users/resolvers/mutations/generateTotpSetup.ts
@@ -35,6 +35,9 @@ function generateBase32Secret(byteLength = 20): string {
  * Initie la configuration TOTP pour l'utilisateur connecté.
  * Génère un nouveau secret, le stocke temporairement (non activé)
  * et retourne le secret en clair et l'URL otpauth pour affichage en QR code.
+ *
+ * Si un setup précédent est incomplet (codes générés mais MFA non finalisée),
+ * les codes orphelins sont supprimés pour repartir sur une base propre.
  */
 const generateTotpSetupResolver: MutationResolvers["generateTotpSetup"] =
   async (_, __, context) => {
@@ -49,11 +52,16 @@ const generateTotpSetupResolver: MutationResolvers["generateTotpSetup"] =
       issuer
     )}&algorithm=SHA1&digits=6&period=30`;
 
-    // Stocker le secret en attente de validation (totpActivatedAt reste null)
-    await prisma.user.update({
-      where: { id: user.id },
-      data: { totpSeed: secret }
-    });
+    // Stocke le nouveau secret et purge les éventuels codes d'un setup incomplet.
+    // Un setup est incomplet quand totpActivatedAt est null mais que des TotpRecoveryCode
+    // existent (confirmTotpSetup appelé sans finalizeMfaSetup ensuite).
+    await prisma.$transaction([
+      prisma.totpRecoveryCode.deleteMany({ where: { userId: user.id } }),
+      prisma.user.update({
+        where: { id: user.id },
+        data: { totpSeed: secret }
+      })
+    ]);
 
     return { secret, qrCodeUrl };
   };

--- a/back/src/users/services/recoveryCode.service.ts
+++ b/back/src/users/services/recoveryCode.service.ts
@@ -1,0 +1,24 @@
+import { compare } from "bcrypt";
+import { prisma } from "@td/prisma";
+
+/**
+ * Cherche un code de récupération valide (non utilisé) parmi les codes de
+ * l'utilisateur. La comparaison est insensible à la casse et ignore les tirets.
+ * Retourne l'id du TotpRecoveryCode correspondant, ou null si aucun ne correspond.
+ */
+export async function findValidRecoveryCode(
+  userId: string,
+  code: string
+): Promise<string | null> {
+  const normalized = code.replace(/-/g, "").toUpperCase();
+  const recoveryCodes = await prisma.totpRecoveryCode.findMany({
+    where: { userId, usedAt: null }
+  });
+
+  for (const rc of recoveryCodes) {
+    if (await compare(normalized, rc.codeHash)) {
+      return rc.id;
+    }
+  }
+  return null;
+}

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -163,6 +163,14 @@ type Mutation {
 
   """
   USAGE INTERNE
+  Finalise l'activation MFA après confirmation de la sauvegarde des codes de récupération.
+  C'est ici que totpActivatedAt est posé et que la MFA devient réellement active.
+  Nécessite que confirmTotpSetup ait été appelé au préalable (codes de récupération générés).
+  """
+  finalizeMfaSetup: Boolean!
+
+  """
+  USAGE INTERNE
   Indique que l'utilisateur a terminé le parcours de reconfiguration MFA obligatoire.
   Remet mustReconfigureMfa à false et accorde l'accès à la plateforme.
   """

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -160,4 +160,11 @@ type Mutation {
   Nécessite un code TOTP valide pour confirmer l'action.
   """
   disableTotp(code: String!): User!
+
+  """
+  USAGE INTERNE
+  Indique que l'utilisateur a terminé le parcours de reconfiguration MFA obligatoire.
+  Remet mustReconfigureMfa à false et accorde l'accès à la plateforme.
+  """
+  completeMfaReconfiguration: User!
 }

--- a/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
@@ -23,6 +23,12 @@ const CONFIRM_TOTP_SETUP = gql`
   }
 `;
 
+const FINALIZE_MFA_SETUP = gql`
+  mutation FinalizeMfaSetup {
+    finalizeMfaSetup
+  }
+`;
+
 // 4 étapes : QR code et validation sont fusionnés dans une même étape
 type Step = "explanation" | "qrcode" | "recovery" | "success";
 
@@ -78,6 +84,9 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
     confirmSetup,
     { loading: confirming, error: confirmError, reset: resetConfirmError }
   ] = useMutation(CONFIRM_TOTP_SETUP);
+
+  const [finalizeSetup, { loading: finalizing, error: finalizeError }] =
+    useMutation(FINALIZE_MFA_SETUP);
 
   const goToQrCode = async () => {
     if (!appInstalled) {
@@ -137,12 +146,15 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
     URL.revokeObjectURL(url);
   };
 
-  const handleFinish = () => {
+  const handleFinish = async () => {
     if (!savedConfirmed) {
       setShowSavedError(true);
       return;
     }
-    setStep("success");
+    const { data } = await finalizeSetup();
+    if (data?.finalizeMfaSetup) {
+      setStep("success");
+    }
   };
 
   const title = "Activez l'authentification TOTP";
@@ -421,11 +433,17 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             )}
           </div>
 
+          {finalizeError && (
+            <DsfrNotificationError apolloError={finalizeError} />
+          )}
+
           <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-mt-3w">
             <Button priority="secondary" onClick={() => setStep("recovery")}>
               Précédent
             </Button>
-            <Button onClick={handleFinish}>Activer</Button>
+            <Button disabled={finalizing} onClick={handleFinish}>
+              Activer
+            </Button>
           </div>
         </div>
       )}

--- a/front/src/Apps/utils/routerUtils.tsx
+++ b/front/src/Apps/utils/routerUtils.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, lazy, Suspense } from "react";
 import {
   Navigate,
   generatePath,
@@ -11,13 +11,17 @@ import routes from "../routes";
 import { useAuth } from "../../common/contexts/AuthContext";
 import { envConfig } from "../../common/envConfig";
 
+const ForcedMfaReconfigurationModal = lazy(
+  () => import("../../login/ForcedMfaReconfigurationModal")
+);
+
 export function RequireAuth({
   children,
   needsAdminPrivilege = false,
   replace = false
 }) {
   const location = useLocation();
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, refreshUser } = useAuth();
 
   useEffect(() => {
     if (envConfig.VITE_SENTRY_DSN && user?.email) {
@@ -35,15 +39,27 @@ export function RequireAuth({
     return <div>Vous n'êtes pas autorisé à consulter cette page</div>;
   }
 
-  return isAuthenticated ? (
-    children
-  ) : (
-    <Navigate
-      to={routes.login}
-      state={{ returnTo: location.pathname + location.search }}
-      replace={replace}
-    />
-  );
+  if (!isAuthenticated) {
+    return (
+      <Navigate
+        to={routes.login}
+        state={{ returnTo: location.pathname + location.search }}
+        replace={replace}
+      />
+    );
+  }
+
+  // L'utilisateur est connecté mais doit reconfigurer sa MFA avant d'accéder
+  // à la plateforme. On affiche le wizard bloquant quelle que soit l'URL.
+  if (user?.mustReconfigureMfa) {
+    return (
+      <Suspense fallback={<Loader />}>
+        <ForcedMfaReconfigurationModal onComplete={refreshUser} />
+      </Suspense>
+    );
+  }
+
+  return children;
 }
 
 export function Redirect({ path }) {

--- a/front/src/common/contexts/AuthContext.tsx
+++ b/front/src/common/contexts/AuthContext.tsx
@@ -11,6 +11,7 @@ type AuthContextType = {
         isAdmin?: boolean | null;
         trackingConsent: boolean;
         trackingConsentUntil?: string | null;
+        mustReconfigureMfa: boolean;
       }
     | undefined;
   refreshUser: () => Promise<void>;
@@ -30,6 +31,7 @@ export const GET_ME = gql`
       isAdmin
       trackingConsent
       trackingConsentUntil
+      mustReconfigureMfa
     }
   }
 `;

--- a/front/src/login/ForcedMfaReconfigurationModal.tsx
+++ b/front/src/login/ForcedMfaReconfigurationModal.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { gql, useMutation } from "@apollo/client";
+import TotpSetupWizard from "../Apps/Account/AccountAuthentication/TotpSetupWizard";
+
+const COMPLETE_MFA_RECONFIGURATION = gql`
+  mutation CompleteMfaReconfiguration {
+    completeMfaReconfiguration {
+      id
+      mustReconfigureMfa
+    }
+  }
+`;
+
+type Props = {
+  onComplete: () => void;
+};
+
+/**
+ * Affiche le parcours de reconfiguration MFA obligatoire.
+ * Bloque l'accès à la plateforme tant que la reconfiguration n'est pas terminée.
+ * Réutilise TotpSetupWizard (configuration TOTP + codes de récupération).
+ * Appelé depuis RequireAuth quand mustReconfigureMfa = true.
+ */
+export default function ForcedMfaReconfigurationModal({ onComplete }: Props) {
+  const [completeMfaReconfiguration] = useMutation(
+    COMPLETE_MFA_RECONFIGURATION
+  );
+
+  const handleSuccess = async () => {
+    await completeMfaReconfiguration();
+    onComplete();
+  };
+
+  return (
+    <TotpSetupWizard
+      onSuccess={handleSuccess}
+      // La modale ne peut pas être fermée : la reconfiguration est obligatoire
+      onClose={() => undefined}
+    />
+  );
+}

--- a/front/src/login/RecoveryCodeModal.tsx
+++ b/front/src/login/RecoveryCodeModal.tsx
@@ -1,0 +1,121 @@
+import React, { createRef, useState } from "react";
+import { Alert } from "@codegouvfr/react-dsfr/Alert";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import TdModal from "../Apps/common/Components/Modal/Modal";
+import { envConfig } from "../common/envConfig";
+
+type RecoveryErrorCode =
+  | "INVALID_RECOVERY_CODE"
+  | "MISSING_RECOVERY_CODE"
+  | "RECOVERY_LOCKOUT";
+
+type Props = {
+  onClose: () => void;
+  errorCode?: RecoveryErrorCode | string | null;
+  returnTo?: string;
+};
+
+const title = "Je n'ai pas accès à l'application";
+
+export default function RecoveryCodeModal({
+  onClose,
+  errorCode,
+  returnTo
+}: Props) {
+  const [code, setCode] = useState("");
+  const formRef = createRef<HTMLFormElement>();
+  const { VITE_API_ENDPOINT } = envConfig;
+
+  const isLockout = errorCode === "RECOVERY_LOCKOUT";
+  const isInvalidCode =
+    errorCode === "INVALID_RECOVERY_CODE" ||
+    errorCode === "MISSING_RECOVERY_CODE";
+
+  const topAlert = isLockout ? (
+    <div className="fr-mb-3w">
+      <Alert
+        title="Compte suspendu"
+        description={
+          <>
+            Suite aux 3 tentatives successives en erreur. Votre compte est
+            temporairement suspendu, contactez notre support via l'Assistance
+            Trackdéchets.
+            <br />
+            <a
+              href="https://assistance.trackdechets.beta.gouv.fr/"
+              className="fr-link "
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Contacter l’assistance.
+            </a>
+          </>
+        }
+        severity="warning"
+      />
+    </div>
+  ) : null;
+  const invalidCodeAlert = isInvalidCode ? (
+    <div className="fr-mb-3w">
+      <Alert
+        title="Clé de récupération invalide"
+        description={
+          <>
+            La clé renseignée est incorrecte, merci de bien vouloir vérifier le
+            code renseigné ou d'en utiliser un autre. Attention 3 tentatives
+            successives en échec déclenchera une suspension du compte.
+          </>
+        }
+        severity="error"
+      />
+    </div>
+  ) : null;
+
+  return (
+    <TdModal isOpen onClose={onClose} ariaLabel={title} title={title} size="L">
+      {topAlert}
+      {invalidCodeAlert}
+      <p className="fr-text--lead fr-mb-3w">
+        Veuillez renseigner la clé de récupération
+      </p>
+      <form
+        ref={formRef}
+        action={`${VITE_API_ENDPOINT}/recovery-login`}
+        method="post"
+      >
+        {returnTo && <input type="hidden" name="returnTo" value={returnTo} />}
+
+        <Input
+          label="Clé de récupération"
+          state={isInvalidCode || isLockout ? "error" : "default"}
+          nativeInputProps={{
+            type: "password",
+            name: "recoveryCode",
+            value: code,
+            autoComplete: "off",
+            placeholder: "Ex : ABCDE-FGHIJ",
+            onChange: e => setCode(e.target.value),
+            disabled: isLockout
+          }}
+        />
+
+        <div className="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-mt-3w">
+          <Button
+            priority="secondary"
+            nativeButtonProps={{ type: "button" }}
+            onClick={onClose}
+          >
+            Fermer ×
+          </Button>
+          <Button
+            nativeButtonProps={{ type: "submit" }}
+            disabled={!code.trim() || isLockout}
+          >
+            Se connecter
+          </Button>
+        </div>
+      </form>
+    </TdModal>
+  );
+}

--- a/front/src/login/RecoveryCodeModal.tsx
+++ b/front/src/login/RecoveryCodeModal.tsx
@@ -83,6 +83,11 @@ export default function RecoveryCodeModal({
         ref={formRef}
         action={`${VITE_API_ENDPOINT}/recovery-login`}
         method="post"
+        onSubmit={e => {
+          if (isLockout) {
+            e.preventDefault();
+          }
+        }}
       >
         {returnTo && <input type="hidden" name="returnTo" value={returnTo} />}
 

--- a/front/src/login/SecondFactor.tsx
+++ b/front/src/login/SecondFactor.tsx
@@ -54,21 +54,96 @@ const RECOVERY_ERROR_CODES = new Set([
   "RECOVERY_LOCKOUT"
 ]);
 
+function buildQueryRedirectState(queries: queryString.ParsedQuery) {
+  const { errorCode, returnTo, username, lockout = 0 } = queries;
+  return {
+    ...(errorCode ? { errorCode, username, lockout } : {}),
+    ...(returnTo ? { returnTo } : {})
+  };
+}
+
+function resolveErrorCode(
+  raw: string | string[] | null | undefined
+): string | null {
+  if (!raw) return null;
+  return Array.isArray(raw) ? raw[0] : raw;
+}
+
+interface TopAlertProps {
+  isLockout: boolean;
+  isAccountSuspended: boolean;
+  lockoutTimestamp: number | undefined;
+}
+
+function TopAlert({
+  isLockout,
+  isAccountSuspended,
+  lockoutTimestamp
+}: TopAlertProps) {
+  if (isLockout) {
+    return (
+      <div className="fr-grid-row fr-mb-3w">
+        <Alert
+          title="Blocage temporaire"
+          description={
+            <>
+              Suite aux 5 tentatives successives en erreur, la connexion est
+              temporairement bloquée. Merci de bien vouloir réessayer{" "}
+              {lockoutTimestamp ? (
+                <Countdown timestamp={lockoutTimestamp} />
+              ) : (
+                "dans 5 minutes."
+              )}
+            </>
+          }
+          severity="warning"
+        />
+      </div>
+    );
+  }
+
+  if (isAccountSuspended) {
+    return (
+      <div className="fr-grid-row fr-mb-3w">
+        <Alert
+          title="Compte suspendu"
+          description={
+            <>
+              Votre compte est temporairement suspendu dans le cadre d'une
+              procédure de récupération en cours. Si vous n'êtes pas à l'origine
+              de cette demande, contactez notre support via l'Assistance
+              Trackdéchets.{" "}
+              <a
+                href="https://faq.trackdechets.fr/contact"
+                className="fr-link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Contacter l'assistance
+              </a>
+            </>
+          }
+          severity="warning"
+        />
+      </div>
+    );
+  }
+
+  return null;
+}
+
 export default function SecondFactor() {
   const location = useLocation();
   const [totp, setTotp] = useState("");
   const formRef = createRef<HTMLFormElement>();
   const { VITE_API_ENDPOINT } = envConfig;
 
-  // Tous les hooks sont déclarés avant tout early return (Rules of Hooks)
-  // On détecte si une erreur de code de récupération est présente dans l'état
-  // pour ré-ouvrir automatiquement la modale après une tentative échouée
   const queries = queryString.parse(location.search);
   const hasQueryParams = !!(queries.errorCode || queries.returnTo);
 
   const stateFromLocation = location.state || {};
   const rawCode = hasQueryParams ? null : stateFromLocation.errorCode;
-  const code = Array.isArray(rawCode) ? rawCode[0] : rawCode;
+  const code = resolveErrorCode(rawCode);
   const isRecoveryError = !!code && RECOVERY_ERROR_CODES.has(code);
 
   const [isRecoveryModalOpen, setIsRecoveryModalOpen] = useState(
@@ -80,14 +155,13 @@ export default function SecondFactor() {
     }
   }, [isRecoveryError, code]);
 
-  // Redirect: query params → location.state (évite l'exposition dans l'URL)
   if (hasQueryParams) {
-    const { errorCode, returnTo, username, lockout = 0 } = queries;
-    const state = {
-      ...(queries.errorCode ? { errorCode, username, lockout } : {}),
-      ...(!!returnTo ? { returnTo } : {})
-    };
-    return <Navigate to={{ pathname: routes.secondFactor }} state={state} />;
+    return (
+      <Navigate
+        to={{ pathname: routes.secondFactor }}
+        state={buildQueryRedirectState(queries)}
+      />
+    );
   }
 
   const { returnTo, lockout } = stateFromLocation;
@@ -96,49 +170,6 @@ export default function SecondFactor() {
   const isLockout = code === "TOTP_LOCKOUT";
   const isAccountSuspended = code === "ACCOUNT_SUSPENDED";
   const isInvalidTotp = code === "INVALID_TOTP" || code === "MISSING_TOTP";
-
-  const topAlert = isLockout ? (
-    <div className="fr-grid-row fr-mb-3w">
-      <Alert
-        title="Blocage temporaire"
-        description={
-          <>
-            Suite aux 5 tentatives successives en erreur, la connexion est
-            temporairement bloquée. Merci de bien vouloir réessayer{" "}
-            {lockoutTimestamp ? (
-              <Countdown timestamp={lockoutTimestamp} />
-            ) : (
-              "dans 5 minutes."
-            )}
-          </>
-        }
-        severity="warning"
-      />
-    </div>
-  ) : isAccountSuspended ? (
-    <div className="fr-grid-row fr-mb-3w">
-      <Alert
-        title="Compte suspendu"
-        description={
-          <>
-            Votre compte est temporairement suspendu dans le cadre d'une
-            procédure de récupération en cours. Si vous n'êtes pas à l'origine
-            de cette demande, contactez notre support via l'Assistance
-            Trackdéchets.{" "}
-            <a
-              href="https://faq.trackdechets.fr/contact"
-              className="fr-link"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Contacter l'assistance
-            </a>
-          </>
-        }
-        severity="warning"
-      />
-    </div>
-  ) : null;
 
   return (
     <div className={styles.onboardingWrapper}>
@@ -157,7 +188,11 @@ export default function SecondFactor() {
         name="login"
       >
         <div className={`fr-container fr-pt-10w ${styles.totpContainer}`}>
-          {topAlert}
+          <TopAlert
+            isLockout={isLockout}
+            isAccountSuspended={isAccountSuspended}
+            lockoutTimestamp={lockoutTimestamp}
+          />
           <div className="fr-grid-row fr-grid-row--center fr-mb-2w">
             <div className="fr-col fr-m-auto">
               <h1 className="fr-h3 fr-mb-3w">

--- a/front/src/login/SecondFactor.tsx
+++ b/front/src/login/SecondFactor.tsx
@@ -9,6 +9,7 @@ import { Input } from "@codegouvfr/react-dsfr/Input";
 
 import styles from "./Login.module.scss";
 import { envConfig } from "../common/envConfig";
+import RecoveryCodeModal from "./RecoveryCodeModal";
 
 function formatDuration(seconds: number): string {
   const minutes = Math.floor(seconds / 60);
@@ -47,14 +48,40 @@ const isProdSandbox =
   import.meta.env.VITE_ENV_NAME === "production" ||
   import.meta.env.VITE_ENV_NAME === "sandbox";
 
+const RECOVERY_ERROR_CODES = new Set([
+  "INVALID_RECOVERY_CODE",
+  "MISSING_RECOVERY_CODE",
+  "RECOVERY_LOCKOUT"
+]);
+
 export default function SecondFactor() {
   const location = useLocation();
   const [totp, setTotp] = useState("");
-  const queries = queryString.parse(location.search);
   const formRef = createRef<HTMLFormElement>();
   const { VITE_API_ENDPOINT } = envConfig;
 
-  if (queries.errorCode || queries.returnTo) {
+  // Tous les hooks sont déclarés avant tout early return (Rules of Hooks)
+  // On détecte si une erreur de code de récupération est présente dans l'état
+  // pour ré-ouvrir automatiquement la modale après une tentative échouée
+  const queries = queryString.parse(location.search);
+  const hasQueryParams = !!(queries.errorCode || queries.returnTo);
+
+  const stateFromLocation = location.state || {};
+  const rawCode = hasQueryParams ? null : stateFromLocation.errorCode;
+  const code = Array.isArray(rawCode) ? rawCode[0] : rawCode;
+  const isRecoveryError = !!code && RECOVERY_ERROR_CODES.has(code);
+
+  const [isRecoveryModalOpen, setIsRecoveryModalOpen] = useState(
+    () => isRecoveryError
+  );
+  useEffect(() => {
+    if (isRecoveryError) {
+      setIsRecoveryModalOpen(true);
+    }
+  }, [isRecoveryError, code]);
+
+  // Redirect: query params → location.state (évite l'exposition dans l'URL)
+  if (hasQueryParams) {
     const { errorCode, returnTo, username, lockout = 0 } = queries;
     const state = {
       ...(queries.errorCode ? { errorCode, username, lockout } : {}),
@@ -63,8 +90,7 @@ export default function SecondFactor() {
     return <Navigate to={{ pathname: routes.secondFactor }} state={state} />;
   }
 
-  const { returnTo, errorCode, lockout } = location.state || {};
-  const code = Array.isArray(errorCode) ? errorCode[0] : errorCode;
+  const { returnTo, lockout } = stateFromLocation;
   const lockoutTimestamp = lockout ? Number(lockout) : undefined;
 
   const isLockout = code === "TOTP_LOCKOUT";
@@ -116,6 +142,14 @@ export default function SecondFactor() {
 
   return (
     <div className={styles.onboardingWrapper}>
+      {isRecoveryModalOpen && (
+        <RecoveryCodeModal
+          onClose={() => setIsRecoveryModalOpen(false)}
+          errorCode={isRecoveryError ? code : null}
+          returnTo={returnTo}
+        />
+      )}
+
       <form
         ref={formRef}
         action={`${VITE_API_ENDPOINT}/otp`}
@@ -158,14 +192,11 @@ export default function SecondFactor() {
                 label="Code d'identification"
               />
 
-              {/* TRA-17923 : ce bouton ouvrira la modale de récupération */}
               {!isProdSandbox && (
                 <button
                   type="button"
                   className="fr-link fr-mb-2w"
-                  onClick={() => {
-                    /* TODO TRA-17923 */
-                  }}
+                  onClick={() => setIsRecoveryModalOpen(true)}
                 >
                   Je n'ai pas accès à l'application
                 </button>

--- a/libs/back/mail/src/templates/index.ts
+++ b/libs/back/mail/src/templates/index.ts
@@ -26,6 +26,12 @@ export const onTotpDisabled: MailTemplate<{ name: string }> = {
   templateId: templateIds.LAYOUT
 };
 
+export const onTotpRecovery: MailTemplate<{ name: string }> = {
+  subject: "Récupération de votre compte Trackdéchets",
+  body: mustacheRenderer("totp-recovery.html"),
+  templateId: templateIds.LAYOUT
+};
+
 export const onSignup: MailTemplate<{ activationHash: string }> = {
   subject: "Activer votre compte sur Trackdéchets",
   body: mustacheRenderer("confirmation-de-compte.html"),

--- a/libs/back/mail/src/templates/mustache/totp-recovery.html
+++ b/libs/back/mail/src/templates/mustache/totp-recovery.html
@@ -50,7 +50,7 @@
     Vous recevez cet e-mail car une opération de sécurité a été effectuée sur le
     compte associé à cette adresse e-mail. Si vous avez des questions, contactez
     notre support via
-    <a href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+    <a href="https://assistance.trackdechets.beta.gouv.fr/"
       >l'Assistance Trackdéchets</a
     >.
   </small>

--- a/libs/back/mail/src/templates/mustache/totp-recovery.html
+++ b/libs/back/mail/src/templates/mustache/totp-recovery.html
@@ -1,0 +1,57 @@
+<p>Bonjour {{name}},</p>
+
+<p>
+  Une récupération de compte vient d'être effectuée sur votre compte
+  Trackdéchets à l'aide d'un code de récupération.
+</p>
+
+<p>Suite à cette opération :</p>
+<ul>
+  <li>votre ancien second facteur d'authentification a été révoqué</li>
+  <li>vos anciens codes de récupération ont été invalidés</li>
+  <li>
+    un nouveau second facteur et de nouveaux codes de récupération ont été
+    configurés
+  </li>
+</ul>
+
+<br />
+
+<p><strong>Cette récupération ne vient pas de vous ?</strong></p>
+
+<p>
+  Si vous n'êtes pas à l'origine de cette action, votre compte a peut-être été
+  compromis. Dans ce cas, agissez immédiatement :
+</p>
+<ul>
+  <li>Changez votre mot de passe</li>
+  <li>
+    Désactivez puis activez à nouveau la double authentification depuis
+    <strong>Mon compte &gt; Authentification</strong>
+  </li>
+  <li>
+    Contactez notre support via
+    <a href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+      >l'Assistance Trackdéchets</a
+    >
+  </li>
+</ul>
+
+<br />
+
+<p>Merci pour votre vigilance.</p>
+
+<p>L'équipe Trackdéchets</p>
+
+<br />
+
+<p>
+  <small>
+    Vous recevez cet e-mail car une opération de sécurité a été effectuée sur le
+    compte associé à cette adresse e-mail. Si vous avez des questions, contactez
+    notre support via
+    <a href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+      >l'Assistance Trackdéchets</a
+    >.
+  </small>
+</p>

--- a/libs/back/prisma/src/migrations/20260604000000_add_mfa_recovery_fields/migration.sql
+++ b/libs/back/prisma/src/migrations/20260604000000_add_mfa_recovery_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: add recovery lockout fields and mustReconfigureMfa flag on User
+ALTER TABLE "User"
+  ADD COLUMN "recoveryFails" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "recoveryLockedUntil" TIMESTAMPTZ(6),
+  ADD COLUMN "mustReconfigureMfa" BOOLEAN NOT NULL DEFAULT false;

--- a/libs/back/prisma/src/models/main.prisma
+++ b/libs/back/prisma/src/models/main.prisma
@@ -927,6 +927,9 @@ model User {
   totpActivatedAt      DateTime?          @db.Timestamptz(6)
   totpFails            Int                @default(0)
   totpLockedUntil      DateTime?
+  recoveryFails        Int                @default(0)
+  recoveryLockedUntil  DateTime?
+  mustReconfigureMfa   Boolean            @default(false)
   trackingConsent      Boolean            @default(false)
   trackingConsentUntil DateTime?
 


### PR DESCRIPTION
# Contexte

Ce ticket met en place le parcours de récupération MFA via code de récupération pour les utilisateurs ayant perdu l’accès à leur application d’authentification. Il permet d’utiliser un code valide depuis une modale dédiée, puis force la révocation de l’ancien TOTP, l’invalidation des anciens codes et la reconfiguration complète de la MFA avant de redonner accès à la plateforme.

# Points de vigilance pour les intégrateurs

### Base de données

**Table modifiée : `User` — `migration.sql`**

```sql
ALTER TABLE "default$default"."User"
  ADD COLUMN "recoveryFails" INTEGER NOT NULL DEFAULT 0,
  ADD COLUMN "recoveryLockedUntil" TIMESTAMPTZ(6),
  ADD COLUMN "mustReconfigureMfa" BOOLEAN NOT NULL DEFAULT false;
```

# Démo

### Si le code est valide:

https://github.com/user-attachments/assets/99a0546d-56f4-4bc3-aff7-ca7b11115ee8

### Si le code est invalide:

https://github.com/user-attachments/assets/42852baa-0b1d-40a3-8535-a1e1d853f602



# Ticket Favro

[Récupérer son compte via un code de récupération](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-17923)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB