### PR TITLE
fix-tra-18374:Quantité affichée en kg au lieu de tonnes dans l’aperçu…

### DIFF
--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -399,6 +399,8 @@ function BsffPackagingAcceptation({
       {isAccepted && (
         <div>
           Quantité réelle présentée : {packaging?.acceptation?.weight} kg
+          {packaging?.acceptation?.weight != null &&
+            ` (${(packaging.acceptation.weight / 1000).toFixed(3)} tonnes)`}
         </div>
       )}
 

--- a/front/src/Apps/Dashboard/Creation/bsff/components/BsffSelectableWasteTable.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsff/components/BsffSelectableWasteTable.tsx
@@ -239,9 +239,7 @@ export default function BsffSelectableWasteTable({
                     {selectedBsff.acceptation?.wasteCode ??
                       selectedBsff.waste?.code}
                     {selectedBsff.acceptation?.weight
-                      ? ` - ${new Decimal(
-                          selectedBsff.acceptation?.weight
-                        ).toFixed(6)} T`
+                      ? ` - ${selectedBsff.acceptation.weight} KG`
                       : ""}
                   </div>
                 ))}

--- a/front/src/Apps/Dashboard/Creation/bsff/components/BsffSelectableWasteTable.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsff/components/BsffSelectableWasteTable.tsx
@@ -5,7 +5,6 @@ import Input from "@codegouvfr/react-dsfr/Input";
 import Accordion from "@codegouvfr/react-dsfr/Accordion";
 import SingleCheckbox from "../../../../common/Components/SingleCheckbox/SingleCheckbox";
 import Alert from "@codegouvfr/react-dsfr/Alert";
-import Decimal from "decimal.js";
 import { ZodBsffGroupingOrForwarding } from "../schema";
 
 export const MAX_BSFF_COUNT_TABLE_DISPLAY = 50;

--- a/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewContent.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewContent.tsx
@@ -158,7 +158,7 @@ const BSFFPreviewContent = ({ bsdId }: BSFFPreviewContentProps) => {
                       : undefined
                   }
                   value={bsd.weight?.value}
-                  units={"t"}
+                  units={"kg"}
                 />
               </PreviewContainerCol>
 

--- a/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewEmitter.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewEmitter.tsx
@@ -38,7 +38,11 @@ const BSFFPreviewEmitter = ({ bsd }: BSFFPreviewEmitterProps) => {
         </PreviewContainerCol>
 
         <PreviewContainerCol gridWidth={3} highlight>
-          <PreviewTextRow label="Poids total" value={bsd.weight?.value} />
+          <PreviewTextRow
+            label="Poids total"
+            value={bsd.weight?.value}
+            units={"kg"}
+          />
 
           <PreviewTextRow
             label="Signé par"

--- a/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewWaste.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewWaste.tsx
@@ -26,12 +26,16 @@ const BSFFPreviewWaste = ({ bsd }: BSFFPreviewWasteProps) => {
                 : undefined
             }
             value={bsd.weight?.value}
-            units={"t"}
+            units={"kg"}
           />
         </PreviewContainerCol>
 
         <PreviewContainerCol gridWidth={4}>
-          <PreviewTextRow label="Quantité réelle reçue" value="-" units={"t"} />
+          <PreviewTextRow
+            label="Quantité réelle reçue"
+            value="-"
+            units={"kg"}
+          />
         </PreviewContainerCol>
       </PreviewContainerRow>
 

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "@nx/storybook": "22.3.1",
     "@nx/vite": "22.3.1",
     "@nx/web": "22.3.1",
-    "@playwright/test": "^1.54.2",
+    "@playwright/test": "1.54.2",
     "@storybook/addon-a11y": "10.1.9",
     "@storybook/addon-docs": "10.1.9",
     "@storybook/addon-links": "10.1.9",

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "@nx/storybook": "22.3.1",
     "@nx/vite": "22.3.1",
     "@nx/web": "22.3.1",
-    "@playwright/test": "1.54.2",
+    "@playwright/test": "^1.54.2",
     "@storybook/addon-a11y": "10.1.9",
     "@storybook/addon-docs": "10.1.9",
     "@storybook/addon-links": "10.1.9",


### PR DESCRIPTION

# Contexte

Afficher la Bonne quantité de Poids soit en Kg sur les diffs modales

# Points de vigilance pour les intégrateurs



# Démo


https://github.com/user-attachments/assets/17b58560-6e4b-416b-9f31-ca555285ca20



# Ticket Favro

[Quantité affichée en kg au lieu de tonnes dans l’aperçu & formulaire du BSFF](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18374)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB