### PR TITLE
feat(TRA-18381): Mentions Légales - Politique de confidentialité a intégrer en page WEB et non PDF

### DIFF
--- a/front/src/Apps/common/Components/layout/Footer.tsx
+++ b/front/src/Apps/common/Components/layout/Footer.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import Modal from "../Modal/Modal";
 import { useCrisp } from "../../hooks/useCrisp";
 import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
 import styles from "./Footer.module.scss";
+import routes from "../../../routes";
 /**
  * ========================
  * TYPES
@@ -188,25 +190,21 @@ export default function AppFooter() {
               </li>
 
               <li className="fr-footer__bottom-item">
-                <a
+                <Link
                   className="fr-footer__bottom-link"
-                  href="/Mentions-legales.pdf"
-                  target="_blank"
-                  rel="noopener"
+                  to={routes.mentionsLegales}
                 >
                   Mentions légales
-                </a>
+                </Link>
               </li>
 
               <li className="fr-footer__bottom-item">
-                <a
+                <Link
                   className="fr-footer__bottom-link"
-                  href="/Politique-de-confidentialite.pdf"
-                  target="_blank"
-                  rel="noopener"
+                  to={routes.politiqueDeConfidentialite}
                 >
                   Politique de confidentialité
-                </a>
+                </Link>
               </li>
 
               <li className="fr-footer__bottom-item">
@@ -273,13 +271,9 @@ export default function AppFooter() {
             <p className="fr-text--md fr-mb-0">
               Ici, vous pouvez voir et personnaliser les informations que nous
               collectons sur vous.{" "}
-              <a
-                href="/politique-de-confidentialite.pdf"
-                target="_blank"
-                rel="noopener"
-              >
+              <Link to={routes.politiqueDeConfidentialite}>
                 Politique de confidentialité
-              </a>
+              </Link>
             </p>
           </div>
 

--- a/front/src/Apps/common/Components/layout/LayoutContainer.tsx
+++ b/front/src/Apps/common/Components/layout/LayoutContainer.tsx
@@ -26,6 +26,8 @@ import PasswordReset from "../../../../login/PasswordReset";
 import MfaReconfiguration from "../../../../login/MfaReconfiguration";
 import Signup from "../../../../login/Signup";
 import WasteTree from "../search/WasteTree";
+import MentionsLegales from "../../../../Pages/Legal/MentionsLegales";
+import PolitiqueDeConfidentialite from "../../../../Pages/Legal/PolitiqueDeConfidentialite";
 
 const Company = lazy(() => import("../../../../Pages/Company/Company"));
 
@@ -88,6 +90,13 @@ export default function LayoutContainer() {
                 <Admin />
               </RequireAuth>
             }
+          />
+
+          <Route path={routes.mentionsLegales} element={<MentionsLegales />} />
+
+          <Route
+            path={routes.politiqueDeConfidentialite}
+            element={<PolitiqueDeConfidentialite />}
           />
 
           <Route path={routes.login} element={<Login />} />

--- a/front/src/Apps/routes.ts
+++ b/front/src/Apps/routes.ts
@@ -143,6 +143,8 @@ const routes = {
       index: "/companies/manage"
     }
   },
+  mentionsLegales: "/mentions-legales",
+  politiqueDeConfidentialite: "/politique-de-confidentialite",
   registry_new: {
     index: "/registry",
     myImports: "/registry/own",
@@ -275,6 +277,9 @@ export const titles = {
   "/companies/join": "",
   "/companies/create": "Ajouter un établissement — Trackdéchets",
   "/companies/manage": "Gestion avancée — Trackdéchets",
+  "/mentions-legales": "Mentions légales — Trackdéchets",
+  "/politique-de-confidentialite":
+    "Politique de confidentialité — Trackdéchets",
   "/registry/own": "Mes imports au registre national — Trackdéchets",
   "/registry/list":
     "Imports au registre national par établissement — Trackdéchets",

--- a/front/src/Pages/Legal/MentionsLegales.tsx
+++ b/front/src/Pages/Legal/MentionsLegales.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+export default function MentionsLegales() {
+  return (
+    <main id="content" role="main" tabIndex={-1}>
+      <div className="fr-container fr-py-6w">
+        <div className="fr-grid-row fr-grid-row--center">
+          <div className="fr-col-12 fr-col-md-10">
+            <h1 className="fr-h1 fr-mb-4w">Mentions légales de Trackdéchets</h1>
+
+            <h2 className="fr-h2 fr-mt-4w fr-mb-2w">
+              Éditeur de la Plateforme
+            </h2>
+            <p>La Plateforme TrackDéchets est éditée par :</p>
+            <p>
+              <strong>Ministère de la Transition écologique</strong>
+              <br />
+              Hôtel de Roquelaure
+              <br />
+              246 boulevard Saint-Germain
+              <br />
+              75007 Paris
+            </p>
+
+            <h2 className="fr-h2 fr-mt-4w fr-mb-2w">
+              Directeur de la publication
+            </h2>
+            <p>
+              Cédric Bourillet, Directeur Général à la Prévention des Risques
+            </p>
+
+            <h2 className="fr-h2 fr-mt-4w fr-mb-2w">
+              Hébergement de la Plateforme
+            </h2>
+            <p>Ce site est hébergé par :</p>
+            <p>
+              <strong>
+                Scalingo SAS 15 avenue du Rhin 67100 Strasbourg France SIRET
+                80866548300018
+              </strong>
+            </p>
+
+            <h2 className="fr-h2 fr-mt-4w fr-mb-2w">Accessibilité</h2>
+            <p>
+              La conformité aux normes d'accessibilité numérique est un objectif
+              ultérieur mais nous tâchons de rendre ce site accessible à toutes
+              et à tous.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-3w fr-mb-2w">
+              Signaler un dysfonctionnement
+            </h3>
+            <p>
+              Si vous rencontrez un défaut d'accessibilité vous empêchant
+              d'accéder à un contenu ou une fonctionnalité du site, merci de
+              nous en faire part (par mail, le tchat ou par courrier). Si vous
+              n'obtenez pas de réponse rapide de notre part, vous êtes en droit
+              de faire parvenir vos doléances ou une demande de saisine au
+              Défenseur des droits.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-3w fr-mb-2w">En savoir plus</h3>
+            <p>
+              Pour en savoir plus sur la politique d'accessibilité numérique de
+              l'État :{" "}
+              <a
+                href="http://references.modernisation.gouv.fr/accessibilite-numerique"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                http://references.modernisation.gouv.fr/accessibilite-numerique
+              </a>
+            </p>
+
+            <h2 className="fr-h2 fr-mt-4w fr-mb-2w">Sécurité</h2>
+            <p>
+              Le site est protégé par un certificat électronique, matérialisé
+              pour la grande majorité des navigateurs par un cadenas. Cette
+              protection participe à la confidentialité des échanges. En aucun
+              cas les services associés à la plateforme ne seront à l'origine
+              d'envoi de courriels pour demander la saisie d'informations
+              personnelles.
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/front/src/Pages/Legal/PolitiqueDeConfidentialite.tsx
+++ b/front/src/Pages/Legal/PolitiqueDeConfidentialite.tsx
@@ -1,0 +1,787 @@
+import React from "react";
+
+export default function PolitiqueDeConfidentialite() {
+  return (
+    <main id="content" role="main" tabIndex={-1}>
+      <div className="fr-container fr-py-6w">
+        <div className="fr-grid-row fr-grid-row--center">
+          <div className="fr-col-12 fr-col-md-10">
+            <h1 className="fr-h1 fr-mb-4w">
+              Politique de confidentialité de Trackdéchets
+            </h1>
+
+            {/* ============================================================
+                POLITIQUE 1
+            ============================================================ */}
+            <h2 className="fr-h2 fr-mt-5w fr-mb-3w">
+              1. Politique relative à la dématérialisation du suivi des déchets,
+              des terres excavées et sédiments
+            </h2>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Responsable de traitement
+            </h3>
+            <p>
+              Le responsable de traitement est la Direction Générale à la
+              Prévention des Risques (DGPR).
+            </p>
+            <ul>
+              <li>Directeur général : Cédric Bourillet.</li>
+              <li>
+                Référent à la protection des données à caractère personnel :
+                Guillaume Lesecq.
+              </li>
+              <li>
+                La DGPR entre dans le périmètre du Ministère de la Transition
+                Écologique (Délégué à la protection des données à caractère
+                personnel : Directrice des Affaires Juridiques, Aurélie
+                Bretonneau).
+              </li>
+            </ul>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Données personnelles traitées
+            </h3>
+            <p>
+              Le présent système informatique traite les données personnelles
+              des utilisateurs suivantes :
+            </p>
+            <ul>
+              <li>
+                Données de profil de l'utilisateur : nom, prénom, adresse de
+                messagerie électronique, numéro de téléphone de l'utilisateur,
+                nom d'établissement professionnel.
+              </li>
+              <li>
+                Données déclarées à la plateforme Trackdéchets : nom, prénom,
+                raison sociale des entreprises individuelles lorsqu'elle
+                comporte un nom ou un prénom, adresse lorsqu'elle se rapporte à
+                un nom ou un prénom.
+              </li>
+              <li>
+                Données collectées dans le cadre de l'inscription à la
+                newsletter : nom, adresse e-mail.
+              </li>
+              <li>
+                Données d'hébergeur : Identifiant de connexion, nature des
+                opérations, heure de l'opération, adresse IP des agents, logs de
+                connexion.
+              </li>
+            </ul>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Finalités des traitements
+            </h3>
+            <p>
+              La plateforme Trackdéchets a pour finalité principale : la
+              traçabilité des déchets dangereux.
+            </p>
+            <p>
+              La plateforme Trackdéchets a pour finalité secondaire : la
+              réalisation d'enquêtes statistiques.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Bases juridiques des traitements de données
+            </h3>
+            <p>
+              Le traitement de données est rendu licite parce qu'il est
+              nécessaire pour répondre à une obligation légale prévue à
+              l'article L.541-7 du code de l'environnement dont les modalités
+              d'application sont précisées par le décret n° 2021-321 du 25 mars
+              2021 relatif à la traçabilité des déchets, des terres excavées et
+              des sédiments.
+            </p>
+            <p>
+              La base légale du traitement des données collectées dans le cadre
+              de l'inscription à la newsletter est le consentement des
+              personnes.
+            </p>
+            <p>
+              La base légale du traitement des données d'hébergeur est une
+              obligation légale.
+            </p>
+            <p>
+              Pour le module de discussion en ligne Crisp, le traitement des
+              données débute <strong>uniquement</strong> lorsque l'utilisateur
+              ouvre manuellement le chatbot. Cette interaction volontaire active
+              des cookies techniques strictement nécessaires à la fourniture du
+              service de discussion.{" "}
+              <strong>
+                Aucun cookie Crisp n'est déposé, ni aucune donnée collectée par
+                Crisp, avant cette action volontaire de l'utilisateur.
+              </strong>
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Durée de conservation des traitements de données
+            </h3>
+
+            <h4 className="fr-h4 fr-mt-3w fr-mb-1w">
+              Données liées aux bordereaux :
+            </h4>
+            <p>
+              La durée de conservation des données à caractère personnel
+              déclarées à la plateforme Trackdéchets est de trois ans en base
+              active, suivie d'un archivage de 3 ans en archivage intermédiaire.
+            </p>
+            <p>
+              La durée de conservation des données liées à la localisation
+              géographique (adresses) est de trois ans en base active, suivie
+              d'un archivage de vingt-sept ans en archivage intermédiaire.
+            </p>
+
+            <h4 className="fr-h4 fr-mt-3w fr-mb-1w">
+              Données liées au compte utilisateur :
+            </h4>
+            <p>
+              La conservation des données à caractère personnel pour
+              s'authentifier à la plateforme Trackdéchets se fait en base active
+              tant que la personne concernée dispose d'un compte utilisateur. À
+              sa fermeture, les données sont archivées 6 ans en archivage
+              intermédiaire.
+            </p>
+
+            <h4 className="fr-h4 fr-mt-3w fr-mb-1w">Données d'hébergeur :</h4>
+            <p>
+              Ces données sont conservées 12 mois, en application de la loi pour
+              la confiance dans l'économie numérique n°2004-575 du 21 juin 2004
+              et de l'article 3 du décret n°2011-219 du 25 février 2011.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Mise en relation avec d'autres traitements de données
+            </h3>
+            <p>
+              Il est prévu que la plateforme Trackdéchets alimente
+              automatiquement et en temps réel le registre national des déchets
+              des terres excavées et sédiments lorsque les données devant être
+              transmises sont intégrées aux bordereaux.
+            </p>
+            <p>
+              Il est prévu que la plateforme Trackdéchets soit directement
+              alimentée en données à partir de logiciels informatiques internes
+              aux entreprises.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Sécurité et confidentialité
+            </h3>
+            <p>
+              Le responsable de traitement s'engage à prendre toutes les mesures
+              techniques et organisationnelles de sécurité nécessaires pour
+              assurer la confidentialité, l'intégrité et pour protéger les
+              données.
+            </p>
+            <p>
+              En cas de violation de données, seront informés les référents
+              métier, la CNIL et les personnes concernées par la violation, dans
+              le respect de notre procédure interne de violation de données.
+              Seront également mises en place le plus rapidement possible toutes
+              les mesures de sécurité nécessaires pour identifier et réparer la
+              faille.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Droits des personnes concernées
+            </h3>
+            <p>
+              En vertu de l'article 13 du règlement (UE) n°2016/679 du Parlement
+              européen et du Conseil du 27 avril 2016 relatif à la protection
+              des personnes physiques à l'égard du traitement des données à
+              caractère personnel et à la libre circulation de ces données, il
+              est rappelé à chaque utilisateur dont les données sont collectées
+              dans le cadre de l'utilisation ou de la connexion à la plateforme
+              Trackdéchets qu'il dispose des droits suivants concernant ses
+              données à caractère personnel :
+            </p>
+            <ul>
+              <li>Droit d'information ;</li>
+              <li>Droit d'accès aux données ;</li>
+              <li>Droit de rectification ;</li>
+              <li>
+                Droit de limitation du traitement relatif à la personne
+                concernée ;
+              </li>
+              <li>
+                Droit au retrait du consentement en matière de cookies et de
+                newsletter uniquement.
+              </li>
+            </ul>
+            <p>
+              Vous pouvez également vous adresser au responsable du traitement à
+              l'adresse électronique suivante :{" "}
+              <a href="mailto:bpgd.sddec.srsedpd.dgpr@developpement-durable.gouv.fr">
+                bpgd.sddec.srsedpd.dgpr@developpement-durable.gouv.fr
+              </a>
+              . Tout courrier électronique qui lui est adressé à propos de la
+              plateforme Trackdéchets doit indiquer en objet « Trackdéchets
+              données personnelles ».
+            </p>
+            <p>
+              Vous pouvez aussi vous adresser au délégué à la protection des
+              données du MTE, à l'adresse suivante :{" "}
+              <a href="mailto:dpd.daj.sg@developpement-durable.gouv.fr">
+                dpd.daj.sg@developpement-durable.gouv.fr
+              </a>
+              . Tout courrier électronique qui lui est adressé à propos de la
+              plateforme Trackdéchets doit l'indiquer en objet.
+            </p>
+            <p>
+              En raison de l'obligation de sécurité et de confidentialité dans
+              le traitement des données à caractère personnel qui incombe au
+              responsable de traitement, votre demande ne sera traitée que si
+              vous rapportez la preuve de votre identité.
+            </p>
+            <p>
+              Délais de réponse : le responsable du traitement s'engage à
+              répondre à votre demande d'accès, de rectification ou toute autre
+              demande complémentaire d'informations dans un délai raisonnable
+              qui ne saurait dépasser 1 mois à compter de la réception de votre
+              demande.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Restriction du droit à l'opposition et à l'effacement
+            </h3>
+            <p>
+              Les traitements de données mis en œuvre par la plateforme
+              Trackdéchets permettent de répondre à une obligation légale prévue
+              à l'article L.541-7 du code de l'environnement. Conformément à la
+              délibération n° 2021-149 du 16 décembre 2021 portant avis sur
+              trois projets d'arrêtés mettant en œuvre un traitement automatisé
+              de données à caractère personnel relatif à la traçabilité des
+              déchets, des terres excavées et sédiments, dès lors que ces
+              traitements de données répondent à une obligation légale, le droit
+              à l'opposition et le droit à l'effacement ne sauraient s'exercer.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">Destinataires</h3>
+            <p>
+              Les données collectées et les demandes, ou dossiers réalisés
+              depuis la plateforme Trackdéchets sont traitées par les seules
+              personnes juridiquement habilitées à connaître des informations
+              traitées.
+            </p>
+            <p>
+              Il s'agit des agents et du personnel compétent, mentionnés dans
+              l'arrêté autorisant le traitement de données à caractère personnel
+              mis en œuvre par la plateforme Trackdéchets.
+            </p>
+            <p>
+              À tout moment, tout utilisateur peut arrêter d'utiliser la
+              plateforme Trackdéchets. Les données liées à l'établissement dont
+              il était membre restent la propriété de l'établissement. En cas de
+              fermeture de la plateforme Trackdéchets, tout utilisateur pourra
+              récupérer ses données.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">Sous-traitants</h3>
+            <p>
+              Certaines des données sont envoyées à l'équipe Trackdéchets qui
+              agit en la qualité de sous-traitant, pour réaliser certaines
+              missions. Le responsable de traitement s'est assuré de la mise en
+              œuvre par l'équipe Trackdéchets de garanties adéquates et du
+              respect de conditions strictes de confidentialité, d'usage et de
+              protection des données.
+            </p>
+            <div className="fr-table fr-table--bordered fr-mt-2w">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Partenaire</th>
+                    <th scope="col">Traitement réalisé</th>
+                    <th scope="col">Pays destinataire</th>
+                    <th scope="col">Garanties</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Scalingo</td>
+                    <td>Hébergement de serveurs web et des bases de données</td>
+                    <td>France</td>
+                    <td>
+                      <a
+                        href="https://scalingo.com/privacy-policy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        https://scalingo.com/privacy-policy
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Brevo</td>
+                    <td>Service d'emailing</td>
+                    <td>France</td>
+                    <td>
+                      <a
+                        href="https://www.brevo.com/fr/rgpd/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        https://www.brevo.com/fr/rgpd/
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Matomo</td>
+                    <td>Analyses et statistiques web</td>
+                    <td>France</td>
+                    <td>
+                      <a
+                        href="https://fr.matomo.org/gdpr-analytics/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        https://fr.matomo.org/gdpr-analytics/
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Crisp IM S.A.R.L.</td>
+                    <td>
+                      Module de discussion en ligne (chatbot), activé uniquement
+                      à l'initiative de l'utilisateur
+                    </td>
+                    <td>France</td>
+                    <td>
+                      <a
+                        href="https://crisp.chat/fr/privacy/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        https://crisp.chat/fr/privacy/
+                      </a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">Cookies</h3>
+            <p>
+              En tant qu'éditeur du présent système d'information, le
+              responsable de traitement pourra faire usage de cookies. Les
+              traceurs ont vocation à être conservés sur le poste informatique
+              de l'Internaute pour une durée allant jusqu'à 13 mois.
+            </p>
+            <p>
+              Certains cookies permettent d'établir des mesures statistiques de
+              fréquentation et d'utilisation du site pouvant être utilisées à
+              des fins de suivi et d'amélioration du service :
+            </p>
+            <ul>
+              <li>
+                Les données collectées ne sont pas recoupées avec d'autres
+                traitements.
+              </li>
+              <li>
+                Le cookie déposé sert uniquement à la production de statistiques
+                anonymes.
+              </li>
+              <li>
+                Le cookie ne permet pas de suivre la navigation de l'internaute
+                sur d'autres sites.
+              </li>
+            </ul>
+            <p>
+              Le module de discussion Crisp dépose des cookies techniques
+              uniquement lorsque l'utilisateur ouvre manuellement le chatbot.
+              Ces cookies sont nécessaires au fonctionnement du service de
+              discussion mais ne sont pas indispensables à l'utilisation du site
+              Trackdéchets.{" "}
+              <strong>
+                Aucun cookie Crisp n'est déposé avant l'activation volontaire du
+                chatbot.
+              </strong>{" "}
+              Vous pouvez gérer vos choix via le module de gestion des cookies
+              disponible en bas de page.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Modification de la politique de confidentialité
+            </h3>
+            <p>
+              Notre politique de confidentialité peut être mise à jour à tout
+              moment. En cas de modification significative des principes de
+              confidentialité appliqués par la plateforme Trackdéchets, la
+              politique révisée sera publiée sur cette page. Si vous continuez à
+              utiliser le service après que ces modifications ont pris effet,
+              vous acceptez la politique révisée.
+            </p>
+            <p>
+              <em>Date de mise à jour : 28 juillet 2025</em>
+            </p>
+
+            <hr className="fr-hr fr-mt-6w fr-mb-6w" />
+
+            {/* ============================================================
+                POLITIQUE 2
+            ============================================================ */}
+            <h2 className="fr-h2 fr-mt-5w fr-mb-3w">
+              2. Politique relative aux autres traitements de données mis en
+              place par Trackdéchets
+            </h2>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Responsable de traitement
+            </h3>
+            <p>
+              Le responsable de traitement est la Direction Générale à la
+              Prévention des Risques (DGPR).
+            </p>
+            <ul>
+              <li>Directeur général : Cédric Bourillet.</li>
+              <li>
+                Référent à la protection des données à caractère personnel :
+                Guillaume Lesecq.
+              </li>
+              <li>
+                La DGPR entre dans le périmètre du Ministère de la Transition
+                Écologique (Délégué à la protection des données à caractère
+                personnel : Directrice des Affaires Juridiques, Aurélie
+                Bretonneau).
+              </li>
+            </ul>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Données personnelles traitées
+            </h3>
+            <p>
+              Le présent système informatique traite les données personnelles
+              des utilisateurs suivantes :
+            </p>
+            <ul>
+              <li>
+                Données de profil de l'utilisateur : nom, adresse e-mail, numéro
+                de téléphone, nom d'établissement professionnel.
+              </li>
+              <li>
+                Données collectées dans le cadre de l'inscription à la
+                newsletter : nom, adresse e-mail.
+              </li>
+              <li>
+                Données d'hébergeur : Identifiant de connexion, nature des
+                opérations, heure de l'opération, adresse IP des agents, logs de
+                connexion.
+              </li>
+            </ul>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Finalités des traitements
+            </h3>
+            <p>La plateforme Trackdéchets a pour finalités :</p>
+            <ul>
+              <li>
+                De faciliter et simplifier l'édition dématérialisée de
+                bordereaux de suivi de déchets.
+              </li>
+              <li>D'assurer la traçabilité et de sécuriser la démarche.</li>
+            </ul>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Bases juridiques des traitements de données
+            </h3>
+            <p>
+              Le traitement de données est rendu licite parce qu'il est
+              nécessaire à l'exécution d'une mission d'intérêt public ou
+              relevant de l'exercice de l'autorité publique dont est investi le
+              responsable de traitement, telle qu'entendue par l'article 6-e du
+              règlement (UE) n°2016/679 du Parlement européen et du Conseil
+              relatif à la protection des personnes physiques à l'égard du
+              traitement des données à caractère personnel et à la libre
+              circulation de ces données.
+            </p>
+            <p>
+              La base légale du traitement des données collectées dans le cadre
+              de l'inscription à la newsletter est le consentement des
+              personnes.
+            </p>
+            <p>
+              La base légale du traitement des données d'hébergeur est une
+              obligation légale.
+            </p>
+            <p>
+              Pour le module de discussion en ligne Crisp, le traitement des
+              données débute <strong>uniquement</strong> lorsque l'utilisateur
+              ouvre manuellement le chatbot. Cette interaction volontaire active
+              des cookies techniques strictement nécessaires à la fourniture du
+              service de discussion.{" "}
+              <strong>
+                Aucun cookie Crisp n'est déposé, ni aucune donnée collectée par
+                Crisp, avant cette action volontaire de l'utilisateur.
+              </strong>
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Durée de conservation des traitements de données
+            </h3>
+
+            <h4 className="fr-h4 fr-mt-3w fr-mb-1w">
+              Données liées aux bordereaux :
+            </h4>
+            <p>
+              La durée de conservation des données à caractère personnel
+              déclarées à la plateforme Trackdéchets est de trois ans en base
+              active, suivie d'un archivage de 3 ans en archivage intermédiaire.
+            </p>
+            <p>
+              La durée de conservation des données liées à la localisation
+              géographique (adresses) est de trois ans en base active, suivie
+              d'un archivage de vingt-sept ans en archivage intermédiaire.
+            </p>
+
+            <h4 className="fr-h4 fr-mt-3w fr-mb-1w">
+              Données collectées dans le cadre de l'inscription à la newsletter
+              :
+            </h4>
+            <p>
+              Les données sont conservées jusqu'au retrait du consentement de la
+              personne.
+            </p>
+
+            <h4 className="fr-h4 fr-mt-3w fr-mb-1w">Données d'hébergeur :</h4>
+            <p>
+              Ces données sont conservées 12 mois, en application de la loi pour
+              la confiance dans l'économie numérique n°2004-575 du 21 juin 2004
+              et de l'article 3 du décret n°2011-219 du 25 février 2011.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Sécurité et confidentialité
+            </h3>
+            <p>
+              Le responsable de traitement s'engage à prendre toutes les mesures
+              techniques et organisationnelles de sécurité nécessaires pour
+              assurer la confidentialité, l'intégrité et pour protéger les
+              données.
+            </p>
+            <p>
+              En cas de violation de données, seront informés les référents
+              métier, la CNIL et les personnes concernées par la violation, dans
+              le respect de notre procédure interne de violation de données.
+              Seront également mises en place le plus rapidement possible toutes
+              les mesures de sécurité nécessaires pour identifier et réparer la
+              faille.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Droits des personnes concernées
+            </h3>
+            <p>
+              En vertu de l'article 13 du règlement (UE) n°2016/679 du Parlement
+              européen et du Conseil du 27 avril 2016 relatif à la protection
+              des personnes physiques à l'égard du traitement des données à
+              caractère personnel et à la libre circulation de ces données, il
+              est rappelé à chaque utilisateur dont les données sont collectées
+              dans le cadre de l'utilisation ou de la connexion à la plateforme
+              Trackdéchets qu'il dispose des droits suivants concernant ses
+              données à caractère personnel :
+            </p>
+            <ul>
+              <li>Droit d'information ;</li>
+              <li>Droit d'accès aux données ;</li>
+              <li>
+                Droit de rectification et droit d'effacement des données ;
+              </li>
+              <li>
+                Droit de limitation du traitement relatif à la personne
+                concernée ;
+              </li>
+              <li>
+                Droit au retrait du consentement en matière de cookies et de
+                newsletter uniquement.
+              </li>
+            </ul>
+            <p>Vous pouvez exercer ces droits en contactant par :</p>
+            <ul>
+              <li>
+                voie électronique :{" "}
+                <a href="mailto:hello@trackdechets.beta.gouv.fr">
+                  hello@trackdechets.beta.gouv.fr
+                </a>
+              </li>
+              <li>
+                voie postale : Ministère de la Transition écologique et
+                solidaire, Direction Générale de la Prévention et des Risques
+                Tour Séquoia - 1 place Carpeaux - 92800 Puteaux
+              </li>
+            </ul>
+            <p>
+              En raison de l'obligation de sécurité et de confidentialité dans
+              le traitement des données à caractère personnel qui incombe au
+              responsable de traitement, votre demande ne sera traitée que si
+              vous rapportez la preuve de votre identité.
+            </p>
+            <p>
+              Délais de réponse : la responsable de traitement s'engage à
+              répondre à votre demande d'accès, de rectification ou d'opposition
+              ou toute autre demande complémentaire d'informations dans un délai
+              raisonnable qui ne saurait dépasser 1 mois à compter de la
+              réception de votre demande.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">Destinataires</h3>
+            <p>
+              Les données collectées et les demandes, ou dossiers réalisés
+              depuis la Plateforme sont traitées par les seules personnes
+              juridiquement habilitées à connaître des informations traitées.
+            </p>
+            <p>
+              Il s'agit des agents, salariés ou autre personne pouvant
+              représenter la personne morale titulaire d'une mission de service
+              public qui utilise le service de la plateforme.
+            </p>
+            <p>
+              À tout moment, tout utilisateur peut arrêter d'utiliser la
+              plateforme. Les données liées à l'établissement dont il était
+              membre restent la propriété de l'établissement. En cas de
+              fermeture de la plateforme, tout utilisateur pourra récupérer ses
+              données.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">Sous-traitants</h3>
+            <p>
+              Certaines des données sont envoyées à l'équipe Trackdéchets qui
+              agit en la qualité de sous-traitant, pour réaliser certaines
+              missions. Le responsable de traitement s'est assuré de la mise en
+              œuvre par l'équipe Trackdéchets de garanties adéquates et du
+              respect de conditions strictes de confidentialité, d'usage et de
+              protection des données.
+            </p>
+            <div className="fr-table fr-table--bordered fr-mt-2w">
+              <table>
+                <thead>
+                  <tr>
+                    <th scope="col">Partenaire</th>
+                    <th scope="col">Traitement réalisé</th>
+                    <th scope="col">Pays destinataire</th>
+                    <th scope="col">Garanties</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Scalingo</td>
+                    <td>Hébergement de serveurs web et des bases de données</td>
+                    <td>France</td>
+                    <td>
+                      <a
+                        href="https://scalingo.com/privacy-policy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        https://scalingo.com/privacy-policy
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Brevo</td>
+                    <td>Service d'emailing</td>
+                    <td>France</td>
+                    <td>
+                      <a
+                        href="https://www.brevo.com/fr/rgpd/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        https://www.brevo.com/fr/rgpd/
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Matomo</td>
+                    <td>Analyses et statistiques web</td>
+                    <td>France</td>
+                    <td>
+                      <a
+                        href="https://fr.matomo.org/gdpr-analytics/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        https://fr.matomo.org/gdpr-analytics/
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Crisp IM S.A.R.L.</td>
+                    <td>
+                      Module de discussion en ligne (chatbot), activé uniquement
+                      à l'initiative de l'utilisateur
+                    </td>
+                    <td>France</td>
+                    <td>
+                      <a
+                        href="https://crisp.chat/fr/privacy/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        https://crisp.chat/fr/privacy/
+                      </a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">Cookies</h3>
+            <p>
+              En tant qu'éditeur de la présente Plateforme, le responsable de
+              traitement pourra faire usage de cookies. Les traceurs ont
+              vocation à être conservés sur le poste informatique de
+              l'Internaute pour une durée allant jusqu'à 13 mois.
+            </p>
+            <p>
+              Certains cookies permettent d'établir des mesures statistiques de
+              fréquentation et d'utilisation du site pouvant être utilisées à
+              des fins de suivi et d'amélioration du service :
+            </p>
+            <ul>
+              <li>
+                Les données collectées ne sont pas recoupées avec d'autres
+                traitements.
+              </li>
+              <li>
+                Le cookie déposé sert uniquement à la production de statistiques
+                anonymes.
+              </li>
+              <li>
+                Le cookie ne permet pas de suivre la navigation de l'internaute
+                sur d'autres sites.
+              </li>
+            </ul>
+            <p>
+              Le module de discussion Crisp dépose des cookies techniques
+              uniquement lorsque l'utilisateur ouvre manuellement le chatbot.
+              Ces cookies sont nécessaires au fonctionnement du service de
+              discussion mais ne sont pas indispensables à l'utilisation du site
+              Trackdéchets.{" "}
+              <strong>
+                Aucun cookie Crisp n'est déposé avant l'activation volontaire du
+                chatbot.
+              </strong>{" "}
+              Vous pouvez gérer vos choix et retirer votre consentement à tout
+              moment via le module de gestion des cookies disponible en bas de
+              page.
+            </p>
+
+            <h3 className="fr-h3 fr-mt-4w fr-mb-2w">
+              Modification de la politique de confidentialité
+            </h3>
+            <p>
+              Notre politique de confidentialité peut être mise à jour à tout
+              moment. En cas de modification significative des principes de
+              confidentialité appliqués par Trackdéchets nous publierons la
+              politique révisée sur cette page. Si vous continuez à utiliser le
+              service après que ces modifications ont pris effet, vous acceptez
+              la politique révisée.
+            </p>
+            <p>
+              <em>Date de mise à jour : 28 juillet 2025</em>
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
# Contexte

Cette PR remplace l’ouverture des PDF “Mentions légales” et “Politique de confidentialité” depuis le footer par des pages Web internes, en cohérence avec le fonctionnement existant des CGU. Elle reprend le contenu des documents fournis et prépare la mise à jour de la politique de confidentialité avec les éléments liés à Crisp et aux cookies demandés dans le ticket.


# Démo

https://github.com/user-attachments/assets/8606fefa-4694-4b31-8116-fabafee530da


# Ticket Favro

[Mentions Légales - Politique de confidentialité a intégrer en page WEB et non PDF](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-18381)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB