### PR TITLE
Feat/tra 13187 : Trackdéchets & Registre exhaustif  : Ajouter Conditionnement : (Nombre, Type et Volume) 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,10 +4,26 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
+
+# [2026.06.2] 30/06/2026
+
+#### :nail_care: Améliorations
+
+- GISTRID : Nvl format numérotation :
+  - Assouplir le contrôle de format sur gistridNumber (BSDD). [PR 4796](https://github.com/MTES-MCT/trackdechets/pull/4796)
+  - Assouplir le contrôle de format sur gistridNumber (déclarations au registre national). [PR 4797](https://github.com/MTES-MCT/trackdechets/pull/4797)
+- Quantité affichée en kg au lieu de tonnes dans l’aperçu & formulaire du BSFF. [PR 4800](https://github.com/MTES-MCT/trackdechets/pull/4800)
+
+#### :bug: Corrections de bugs
+
+- BSDD : Blocage signature transporteur si informations de contact absents malgré saisie dans la modale. [PR 4795](https://github.com/MTES-MCT/trackdechets/pull/4795)
+- VHU, BSFF et BSDA : Blocage modification transporteur si date de prise en charge enregistrée mais signature échouée (API). [PR 4794](https://github.com/MTES-MCT/trackdechets/pull/4794)
+- BSDD - API : absence de contrôle des informations de contact du transporteur vers l’exutoire final. [PR 4795](https://github.com/MTES-MCT/trackdechets/pull/4795)
+
 # [2026.06.1] 02/06/2026
 
 #### :nail_care: Améliorations
-  
+
 - BSFF => Refonte & DSFR :
   - Implémenter l'onglet Déchet du BSFF au DSFR
   - Implémenter l'onglet Opérateur du BSFF au DSFR
@@ -18,7 +34,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
   - Mettre la modale de signature transporteur au DSFR
   - Mettre la modale de signature Mettre la modale de signature du destinataire au DSFR
   - Implémentation la modale "Aperçu" au DSFR [PR 4771](https://github.com/MTES-MCT/trackdechets/pull/4771)
-  
+
 #### :bug: Corrections de bugs
 
 - BSFF: Pouvoir modifier le conditionnement sur le BSFF de reconditionnement, regroupement et réexpédition. [PR 4778](https://github.com/MTES-MCT/trackdechets/pull/4778)

--- a/back/src/bsda/__tests__/registryV2.integration.ts
+++ b/back/src/bsda/__tests__/registryV2.integration.ts
@@ -26,7 +26,7 @@ describe("registryV2", () => {
     const incomingWaste = toIncomingWasteV2(dbBsda as RegistryV2Bsda);
 
     // Then
-    expect(incomingWaste.quantity).toBe(10);
+    expect(incomingWaste.quantity).toBe("3: Palette filmée | 7: Dépôt-bag");
   });
 
   it("quantity should be null if no packaging", async () => {

--- a/back/src/bsda/registryV2.ts
+++ b/back/src/bsda/registryV2.ts
@@ -41,15 +41,38 @@ import { isFinalOperationCode } from "../common/operationCodes";
 import { logger } from "@td/logger";
 import { bsdaWasteQuantities } from "./utils";
 
+const packagingLabels: Record<string, string> = {
+  BIG_BAG: "Big-bag / GRV",
+  DEPOT_BAG: "Dépôt-bag",
+  PALETTE_FILME: "Palette filmée",
+  SAC_RENFORCE: "Sac renforcé",
+  CONTENEUR_BAG: "Conteneur-bag",
+  OTHER: "Autre"
+};
+
 const getQuantity = (packagings: Prisma.JsonValue) => {
-  if (!packagings || !(packagings as PackagingInfo[])?.length) {
+  const values = packagings as PackagingInfo[] | null;
+
+  if (!values?.length) {
     return null;
   }
 
-  return (packagings as PackagingInfo[])?.reduce(
-    (totalQuantity, p) => totalQuantity + (p.quantity ?? 0),
-    0
-  );
+  const grouped = new Map<string, number>();
+
+  for (const packaging of values) {
+    const type =
+      packaging.type === "OTHER"
+        ? `${packagingLabels.OTHER}${
+            packaging.other ? ` (${packaging.other})` : ""
+          }`
+        : packagingLabels[packaging.type] ?? packaging.type;
+
+    grouped.set(type, (grouped.get(type) ?? 0) + (packaging.quantity ?? 0));
+  }
+
+  return [...grouped.entries()]
+    .map(([type, quantity]) => `${quantity}: ${type}`)
+    .join(" | ");
 };
 
 const getInitialEmitterData = (bsda: RegistryV2Bsda) => {

--- a/back/src/bsda/registryV2.ts
+++ b/back/src/bsda/registryV2.ts
@@ -40,40 +40,20 @@ import { prisma } from "@td/prisma";
 import { isFinalOperationCode } from "../common/operationCodes";
 import { logger } from "@td/logger";
 import { bsdaWasteQuantities } from "./utils";
+import {
+  BSDA_PACKAGING_LABELS,
+  formatGroupedPackagingQuantity
+} from "../registryV2/packagings";
 
-const packagingLabels: Record<string, string> = {
-  BIG_BAG: "Big-bag / GRV",
-  DEPOT_BAG: "Dépôt-bag",
-  PALETTE_FILME: "Palette filmée",
-  SAC_RENFORCE: "Sac renforcé",
-  CONTENEUR_BAG: "Conteneur-bag",
-  OTHER: "Autre"
-};
-
-const getQuantity = (packagings: Prisma.JsonValue) => {
-  const values = packagings as PackagingInfo[] | null;
-
-  if (!values?.length) {
-    return null;
-  }
-
-  const grouped = new Map<string, number>();
-
-  for (const packaging of values) {
-    const type =
-      packaging.type === "OTHER"
-        ? `${packagingLabels.OTHER}${
-            packaging.other ? ` (${packaging.other})` : ""
-          }`
-        : packagingLabels[packaging.type] ?? packaging.type;
-
-    grouped.set(type, (grouped.get(type) ?? 0) + (packaging.quantity ?? 0));
-  }
-
-  return [...grouped.entries()]
-    .map(([type, quantity]) => `${quantity}: ${type}`)
-    .join(" | ");
-};
+const getQuantity = (packagings: Prisma.JsonValue) =>
+  formatGroupedPackagingQuantity(
+    packagings as PackagingInfo[] | null,
+    BSDA_PACKAGING_LABELS,
+    {
+      otherType: "OTHER",
+      useQuantityField: true
+    }
+  );
 
 const getInitialEmitterData = (bsda: RegistryV2Bsda) => {
   const initialEmitter: Record<string, string | null> = {

--- a/back/src/bsdasris/registryV2.ts
+++ b/back/src/bsdasris/registryV2.ts
@@ -1,4 +1,5 @@
 import {
+  BsdasriPackaging,
   IncomingWasteV2,
   OutgoingWasteV2,
   TransportedWasteV2,
@@ -73,6 +74,38 @@ const getFinalOperationsData = (bsdasri: RegistryV2Bsdasri) => {
   };
 };
 
+const packagingLabels: Record<string, string> = {
+  BOITE_CARTON: "Caisse(s) en carton avec sac en plastique",
+  FUT: "Fût(s)",
+  BOITE_PERFORANTS: "Boîte(s) et Mini-collecteurs pour déchets perforants",
+  GRAND_EMBALLAGE: "Grand(s) emballage(s)",
+  GRV: "Grand(s) récipient(s) pour vrac",
+  AUTRE: "Autre(s)"
+};
+
+const getQuantity = (packagings: BsdasriPackaging[]) => {
+  if (!packagings?.length) {
+    return null;
+  }
+
+  const grouped = new Map<string, number>();
+
+  for (const packaging of packagings) {
+    const type =
+      packaging.type === "AUTRE"
+        ? `${packagingLabels.AUTRE}${
+            packaging.other ? ` (${packaging.other})` : ""
+          }`
+        : packagingLabels[packaging.type];
+
+    grouped.set(type, (grouped.get(type) ?? 0) + (packaging.quantity ?? 0));
+  }
+
+  return [...grouped.entries()]
+    .map(([type, quantity]) => `${quantity}: ${type}`)
+    .join(" | ");
+};
+
 export const toIncomingWasteV2 = (
   bsdasri: RegistryV2Bsdasri
 ): Omit<Required<IncomingWasteV2>, "__typename"> => {
@@ -123,7 +156,7 @@ export const toIncomingWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bsdasri.emitterWastePackagings as BsdasriPackaging[]),
     wasteContainsElectricOrHybridVehicles: null,
     weight: kgToTonRegistryV2(bsdasri.emitterWasteWeightValue),
     initialEmitterCompanyName: null,
@@ -286,7 +319,7 @@ export const toOutgoingWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bsdasri.emitterWastePackagings as BsdasriPackaging[]),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsdasri.emitterWasteWeightValue
       ? kgToTonRegistryV2(bsdasri.emitterWasteWeightValue)
@@ -472,7 +505,7 @@ export const toTransportedWasteV2 = (
     wastePop: false,
     wasteIsDangerous: true,
     weight: kgToTonRegistryV2(bsdasri.emitterWasteWeightValue),
-    quantity: null,
+    quantity: getQuantity(bsdasri.emitterWastePackagings as BsdasriPackaging[]),
     wasteContainsElectricOrHybridVehicles: null,
     weightIsEstimate: bsdasri.emitterWasteWeightIsEstimate,
     volume: null,
@@ -619,7 +652,7 @@ export const toManagedWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bsdasri.emitterWastePackagings as BsdasriPackaging[]),
     wasteContainsElectricOrHybridVehicles: null,
 
     weight: kgToTonRegistryV2(bsdasri.emitterWasteWeightValue),
@@ -789,7 +822,7 @@ export const toAllWasteV2 = (
     wasteCode: bsdasri.wasteCode,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bsdasri.emitterWastePackagings as BsdasriPackaging[]),
     wasteContainsElectricOrHybridVehicles: null,
     weight: kgToTonRegistryV2(bsdasri.emitterWasteWeightValue),
     weightIsEstimate: bsdasri.emitterWasteWeightIsEstimate,

--- a/back/src/bsdasris/registryV2.ts
+++ b/back/src/bsdasris/registryV2.ts
@@ -36,6 +36,10 @@ import {
 import { prisma } from "@td/prisma";
 import { isFinalOperationCode } from "../common/operationCodes";
 import { logger } from "@td/logger";
+import {
+  BSDASRI_PACKAGING_LABELS,
+  formatGroupedPackagingQuantity
+} from "../registryV2/packagings";
 
 const getFinalOperationsData = (bsdasri: RegistryV2Bsdasri) => {
   const destinationFinalOperationCodes: string[] = [];
@@ -74,37 +78,10 @@ const getFinalOperationsData = (bsdasri: RegistryV2Bsdasri) => {
   };
 };
 
-const packagingLabels: Record<string, string> = {
-  BOITE_CARTON: "Caisse(s) en carton avec sac en plastique",
-  FUT: "Fût(s)",
-  BOITE_PERFORANTS: "Boîte(s) et Mini-collecteurs pour déchets perforants",
-  GRAND_EMBALLAGE: "Grand(s) emballage(s)",
-  GRV: "Grand(s) récipient(s) pour vrac",
-  AUTRE: "Autre(s)"
-};
-
-const getQuantity = (packagings: BsdasriPackaging[]) => {
-  if (!packagings?.length) {
-    return null;
-  }
-
-  const grouped = new Map<string, number>();
-
-  for (const packaging of packagings) {
-    const type =
-      packaging.type === "AUTRE"
-        ? `${packagingLabels.AUTRE}${
-            packaging.other ? ` (${packaging.other})` : ""
-          }`
-        : packagingLabels[packaging.type];
-
-    grouped.set(type, (grouped.get(type) ?? 0) + (packaging.quantity ?? 0));
-  }
-
-  return [...grouped.entries()]
-    .map(([type, quantity]) => `${quantity}: ${type}`)
-    .join(" | ");
-};
+const getQuantity = (packagings: BsdasriPackaging[]) =>
+  formatGroupedPackagingQuantity(packagings, BSDASRI_PACKAGING_LABELS, {
+    useQuantityField: true
+  });
 
 export const toIncomingWasteV2 = (
   bsdasri: RegistryV2Bsdasri

--- a/back/src/bsffs/registryV2.ts
+++ b/back/src/bsffs/registryV2.ts
@@ -38,35 +38,13 @@ import { Nullable } from "../types";
 import { isFinalOperation } from "./constants";
 import { logger } from "@td/logger";
 import { BsffWithTransporters } from "./types";
-const packagingLabels: Record<string, string> = {
-  BOUTEILLE: "Bouteille",
-  CITERNE: "Citerne",
-  CONTENEUR: "Conteneur",
-  AUTRE: "Autre"
-};
+import {
+  BSFF_PACKAGING_LABELS,
+  formatGroupedPackagingQuantity
+} from "../registryV2/packagings";
 
-const getQuantity = (packagings: BsffPackaging[]) => {
-  if (!packagings?.length) {
-    return null;
-  }
-
-  const grouped = new Map<string, number>();
-
-  for (const packaging of packagings) {
-    const type =
-      packaging.type === "AUTRE"
-        ? `${packagingLabels.AUTRE}${
-            packaging.other ? ` (${packaging.other})` : ""
-          }`
-        : packagingLabels[packaging.type] ?? packaging.type;
-
-    grouped.set(type, (grouped.get(type) ?? 0) + 1);
-  }
-
-  return [...grouped.entries()]
-    .map(([type, quantity]) => `${quantity}: ${type}`)
-    .join(" | ");
-};
+const getQuantity = (packagings: BsffPackaging[]) =>
+  formatGroupedPackagingQuantity(packagings, BSFF_PACKAGING_LABELS);
 
 const getInitialEmitterData = (bsff: RegistryV2Bsff) => {
   const initialEmitter: Record<string, string | null> = {

--- a/back/src/bsffs/registryV2.ts
+++ b/back/src/bsffs/registryV2.ts
@@ -38,6 +38,35 @@ import { Nullable } from "../types";
 import { isFinalOperation } from "./constants";
 import { logger } from "@td/logger";
 import { BsffWithTransporters } from "./types";
+const packagingLabels: Record<string, string> = {
+  BOUTEILLE: "Bouteille",
+  CITERNE: "Citerne",
+  CONTENEUR: "Conteneur",
+  AUTRE: "Autre"
+};
+
+const getQuantity = (packagings: BsffPackaging[]) => {
+  if (!packagings?.length) {
+    return null;
+  }
+
+  const grouped = new Map<string, number>();
+
+  for (const packaging of packagings) {
+    const type =
+      packaging.type === "AUTRE"
+        ? `${packagingLabels.AUTRE}${
+            packaging.other ? ` (${packaging.other})` : ""
+          }`
+        : packagingLabels[packaging.type] ?? packaging.type;
+
+    grouped.set(type, (grouped.get(type) ?? 0) + 1);
+  }
+
+  return [...grouped.entries()]
+    .map(([type, quantity]) => `${quantity}: ${type}`)
+    .join(" | ");
+};
 
 const getInitialEmitterData = (bsff: RegistryV2Bsff) => {
   const initialEmitter: Record<string, string | null> = {
@@ -333,7 +362,7 @@ export const toIncomingWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bsff.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: kgToTonRegistryV2(bsff.weightValue),
     initialEmitterCompanyName,
@@ -565,7 +594,7 @@ export const toOutgoingWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bsff.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: kgToTonRegistryV2(bsff.weightValue),
     volume: null,
@@ -844,7 +873,7 @@ export const toTransportedWasteV2 = (
     wastePop: false,
     wasteIsDangerous: true,
     weight: kgToTonRegistryV2(bsff.weightValue),
-    quantity: null,
+    quantity: getQuantity(bsff.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weightIsEstimate: false,
     volume: null,
@@ -1101,7 +1130,7 @@ export const toAllWasteV2 = (
     wasteCode: bsff.wasteCode,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bsff.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: kgToTonRegistryV2(bsff.weightValue),
     initialEmitterCompanyName,

--- a/back/src/bspaoh/registryV2.ts
+++ b/back/src/bspaoh/registryV2.ts
@@ -35,6 +35,32 @@ import {
 import { logger } from "@td/logger";
 import { BspaohForElastic } from "./elastic";
 
+const packagingLabels: Record<string, string> = {
+  RELIQUAIRE: "Reliquaire",
+  LITTLE_BOX: "Petite boîte",
+  BIG_BOX: "Grande boîte"
+};
+
+const getQuantity = (packagings: Prisma.JsonValue) => {
+  const values = packagings as { type: string }[] | null;
+
+  if (!values?.length) {
+    return null;
+  }
+
+  const grouped = new Map<string, number>();
+
+  for (const packaging of values) {
+    const type = packagingLabels[packaging.type] ?? packaging.type;
+
+    grouped.set(type, (grouped.get(type) ?? 0) + 1);
+  }
+
+  return [...grouped.entries()]
+    .map(([type, quantity]) => `${quantity}: ${type}`)
+    .join(" | ");
+};
+
 export const toIncomingWasteV2 = (
   bspaoh: RegistryV2Bspaoh
 ): Omit<Required<IncomingWasteV2>, "__typename"> => {
@@ -86,7 +112,7 @@ export const toIncomingWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bspaoh.wastePackagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: kgToTonRegistryV2(bspaoh.emitterWasteWeightValue),
     initialEmitterCompanyName: null,
@@ -230,7 +256,7 @@ export const toOutgoingWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bspaoh.wastePackagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: kgToTonRegistryV2(bspaoh.emitterWasteWeightValue),
     weightIsEstimate: bspaoh.emitterWasteWeightIsEstimate,
@@ -407,7 +433,7 @@ export const toTransportedWasteV2 = (
     wastePop: false,
     wasteIsDangerous: true,
     weight: kgToTonRegistryV2(bspaoh.emitterWasteWeightValue),
-    quantity: null,
+    quantity: getQuantity(bspaoh.wastePackagings),
     wasteContainsElectricOrHybridVehicles: null,
     weightIsEstimate: bspaoh.emitterWasteWeightIsEstimate,
     volume: null,
@@ -548,7 +574,7 @@ export const toAllWasteV2 = (
     wasteCode: bspaoh.wasteCode,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bspaoh.wastePackagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: kgToTonRegistryV2(bspaoh.emitterWasteWeightValue),
     weightIsEstimate: bspaoh.emitterWasteWeightIsEstimate,

--- a/back/src/bspaoh/registryV2.ts
+++ b/back/src/bspaoh/registryV2.ts
@@ -34,32 +34,16 @@ import {
 } from "@td/registry";
 import { logger } from "@td/logger";
 import { BspaohForElastic } from "./elastic";
+import {
+  BSPAOH_PACKAGING_LABELS,
+  formatGroupedPackagingQuantity
+} from "../registryV2/packagings";
 
-const packagingLabels: Record<string, string> = {
-  RELIQUAIRE: "Reliquaire",
-  LITTLE_BOX: "Petite boîte",
-  BIG_BOX: "Grande boîte"
-};
-
-const getQuantity = (packagings: Prisma.JsonValue) => {
-  const values = packagings as { type: string }[] | null;
-
-  if (!values?.length) {
-    return null;
-  }
-
-  const grouped = new Map<string, number>();
-
-  for (const packaging of values) {
-    const type = packagingLabels[packaging.type] ?? packaging.type;
-
-    grouped.set(type, (grouped.get(type) ?? 0) + 1);
-  }
-
-  return [...grouped.entries()]
-    .map(([type, quantity]) => `${quantity}: ${type}`)
-    .join(" | ");
-};
+const getQuantity = (packagings: Prisma.JsonValue) =>
+  formatGroupedPackagingQuantity(
+    packagings as { type: string }[] | null,
+    BSPAOH_PACKAGING_LABELS
+  );
 
 export const toIncomingWasteV2 = (
   bspaoh: RegistryV2Bspaoh

--- a/back/src/bsvhu/registryV2.ts
+++ b/back/src/bsvhu/registryV2.ts
@@ -36,6 +36,24 @@ import { BsvhuForElastic } from "./elastic";
 import { getFirstTransporterSync, getTransportersSync } from "./database";
 import { getTransporterCompanyOrgId } from "@td/constants";
 
+const packagingLabels: Record<string, string> = {
+  UNITE: "unités",
+  LOT: "lots"
+};
+
+const getQuantity = (
+  quantity: number | null | undefined,
+  packaging: string | null | undefined
+) => {
+  if (quantity == null) {
+    return null;
+  }
+
+  const label = packaging ? packagingLabels[packaging] ?? packaging : "";
+
+  return label ? `${quantity}: ${label}` : `${quantity}`;
+};
+
 export const toIncomingWasteV2 = (
   bsvhu: RegistryV2Bsvhu
 ): Omit<Required<IncomingWasteV2>, "__typename"> => {
@@ -136,7 +154,7 @@ export const toIncomingWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: bsvhu.quantity,
+    quantity: getQuantity(bsvhu.quantity, bsvhu.packaging),
     wasteContainsElectricOrHybridVehicles:
       bsvhu.containsElectricOrHybridVehicles,
     weight: kgToTonRegistryV2(bsvhu.weightValue),
@@ -363,7 +381,7 @@ export const toOutgoingWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: bsvhu.quantity,
+    quantity: getQuantity(bsvhu.quantity, bsvhu.packaging),
     wasteContainsElectricOrHybridVehicles:
       bsvhu.containsElectricOrHybridVehicles,
     weight: kgToTonRegistryV2(bsvhu.weightValue),
@@ -647,7 +665,7 @@ export const toTransportedWasteV2 = (
     wastePop: false,
     wasteIsDangerous: true,
     weight: kgToTonRegistryV2(bsvhu.weightValue),
-    quantity: bsvhu.quantity,
+    quantity: getQuantity(bsvhu.quantity, bsvhu.packaging),
     wasteContainsElectricOrHybridVehicles:
       bsvhu.containsElectricOrHybridVehicles,
     weightIsEstimate: bsvhu.weightIsEstimate,
@@ -905,7 +923,7 @@ export const toManagedWasteV2 = (
     wasteCodeBale: null,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: bsvhu.quantity,
+    quantity: getQuantity(bsvhu.quantity, bsvhu.packaging),
     wasteContainsElectricOrHybridVehicles:
       bsvhu.containsElectricOrHybridVehicles,
     weight: kgToTonRegistryV2(bsvhu.weightValue),
@@ -1179,7 +1197,7 @@ export const toAllWasteV2 = (
     wasteCode: bsvhu.wasteCode,
     wastePop: false,
     wasteIsDangerous: true,
-    quantity: bsvhu.quantity,
+    quantity: getQuantity(bsvhu.quantity, bsvhu.packaging),
     wasteContainsElectricOrHybridVehicles:
       bsvhu.containsElectricOrHybridVehicles,
     weight: kgToTonRegistryV2(bsvhu.weightValue),

--- a/back/src/bsvhu/registryV2.ts
+++ b/back/src/bsvhu/registryV2.ts
@@ -35,24 +35,15 @@ import { logger } from "@td/logger";
 import { BsvhuForElastic } from "./elastic";
 import { getFirstTransporterSync, getTransportersSync } from "./database";
 import { getTransporterCompanyOrgId } from "@td/constants";
-
-const packagingLabels: Record<string, string> = {
-  UNITE: "unités",
-  LOT: "lots"
-};
+import {
+  BSVHU_PACKAGING_LABELS,
+  formatSinglePackagingQuantity
+} from "../registryV2/packagings";
 
 const getQuantity = (
   quantity: number | null | undefined,
   packaging: string | null | undefined
-) => {
-  if (quantity == null) {
-    return null;
-  }
-
-  const label = packaging ? packagingLabels[packaging] ?? packaging : "";
-
-  return label ? `${quantity}: ${label}` : `${quantity}`;
-};
+) => formatSinglePackagingQuantity(quantity, packaging, BSVHU_PACKAGING_LABELS);
 
 export const toIncomingWasteV2 = (
   bsvhu: RegistryV2Bsvhu

--- a/back/src/forms/registryV2.ts
+++ b/back/src/forms/registryV2.ts
@@ -40,6 +40,7 @@ import {
 } from "@td/constants";
 import { logger } from "@td/logger";
 import { FormForElastic } from "./elastic";
+import { packagingLabels } from "../registryV2/utils";
 
 const getInitialEmitterData = (bsdd: BsddV2) => {
   const initialEmitter: Record<string, string | null> = {
@@ -130,14 +131,29 @@ const getFinalOperationsData = (bsdd: BsddV2) => {
   };
 };
 
-const getQuantity = (packagings: PackagingInfo[]) => {
-  if (!packagings) {
+const getQuantity = (packagings: PackagingInfo[], isDirectSupply: boolean) => {
+  if (isDirectSupply) {
+    return `N/A: ${packagingLabels.PIPELINE}`;
+  }
+
+  if (!packagings?.length) {
     return null;
   }
-  return packagings.reduce(
-    (totalQuantity, p) => totalQuantity + (p.quantity ?? 0),
-    0
-  );
+
+  const grouped = new Map<string, number>();
+
+  for (const packaging of packagings) {
+    const type =
+      packaging.type === "AUTRE"
+        ? `Autre${packaging.other ? ` (${packaging.other})` : ""}`
+        : packagingLabels[packaging.type];
+
+    grouped.set(type, (grouped.get(type) ?? 0) + (packaging.quantity ?? 0));
+  }
+
+  return [...grouped.entries()]
+    .map(([type, quantity]) => `${quantity}: ${type}`)
+    .join(" | ");
 };
 
 const getWasteType = (bsdd: MinimalBsddForLookup): RegistryExportWasteType => {
@@ -252,7 +268,7 @@ export const toIncomingWasteV2 = (
     wasteCodeBale: null,
     wastePop: bsdd.pop,
     wasteIsDangerous: bsdd.wasteIsDangerous,
-    quantity: getQuantity(bsdd.packagings),
+    quantity: getQuantity(bsdd.packagings, bsdd.isDirectSupply),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsdd.weightValue,
     initialEmitterCompanyName,
@@ -521,7 +537,7 @@ export const toOutgoingWasteV2 = (
     wasteCodeBale: null,
     wastePop: bsdd.pop,
     wasteIsDangerous: bsdd.wasteIsDangerous,
-    quantity: getQuantity(bsdd.packagings),
+    quantity: getQuantity(bsdd.packagings, bsdd.isDirectSupply),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsdd.weightValue,
     weightIsEstimate: bsdd.weightIsEstimate,
@@ -804,7 +820,7 @@ export const toTransportedWasteV2 = (
     wastePop: bsdd.pop,
     wasteIsDangerous: bsdd.wasteIsDangerous,
     weight: bsdd.weightValue,
-    quantity: getQuantity(bsdd.packagings),
+    quantity: getQuantity(bsdd.packagings, bsdd.isDirectSupply),
     wasteContainsElectricOrHybridVehicles: null,
     weightIsEstimate: bsdd.weightIsEstimate,
     volume: null,
@@ -1064,7 +1080,7 @@ export const toManagedWasteV2 = (
     wasteCodeBale: null,
     wastePop: bsdd.pop,
     wasteIsDangerous: bsdd.wasteIsDangerous,
-    quantity: getQuantity(bsdd.packagings),
+    quantity: getQuantity(bsdd.packagings, bsdd.isDirectSupply),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsdd.weightValue,
     weightIsEstimate: bsdd.weightIsEstimate,
@@ -1351,7 +1367,7 @@ export const toAllWasteV2 = (
     wasteCode: bsdd.wasteCode,
     wastePop: bsdd.pop,
     wasteIsDangerous: bsdd.wasteIsDangerous,
-    quantity: getQuantity(bsdd.packagings),
+    quantity: getQuantity(bsdd.packagings, bsdd.isDirectSupply),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsdd.weightValue,
     weightIsEstimate: bsdd.weightIsEstimate,

--- a/back/src/forms/registryV2.ts
+++ b/back/src/forms/registryV2.ts
@@ -40,7 +40,10 @@ import {
 } from "@td/constants";
 import { logger } from "@td/logger";
 import { FormForElastic } from "./elastic";
-import { packagingLabels } from "../registryV2/utils";
+import {
+  BSDD_PACKAGING_LABELS,
+  formatGroupedPackagingQuantity
+} from "../registryV2/packagings";
 
 const getInitialEmitterData = (bsdd: BsddV2) => {
   const initialEmitter: Record<string, string | null> = {
@@ -133,27 +136,12 @@ const getFinalOperationsData = (bsdd: BsddV2) => {
 
 const getQuantity = (packagings: PackagingInfo[], isDirectSupply: boolean) => {
   if (isDirectSupply) {
-    return `N/A: ${packagingLabels.PIPELINE}`;
+    return `N/A: ${BSDD_PACKAGING_LABELS.PIPELINE}`;
   }
 
-  if (!packagings?.length) {
-    return null;
-  }
-
-  const grouped = new Map<string, number>();
-
-  for (const packaging of packagings) {
-    const type =
-      packaging.type === "AUTRE"
-        ? `Autre${packaging.other ? ` (${packaging.other})` : ""}`
-        : packagingLabels[packaging.type];
-
-    grouped.set(type, (grouped.get(type) ?? 0) + (packaging.quantity ?? 0));
-  }
-
-  return [...grouped.entries()]
-    .map(([type, quantity]) => `${quantity}: ${type}`)
-    .join(" | ");
+  return formatGroupedPackagingQuantity(packagings, BSDD_PACKAGING_LABELS, {
+    useQuantityField: true
+  });
 };
 
 const getWasteType = (bsdd: MinimalBsddForLookup): RegistryExportWasteType => {

--- a/back/src/registryV2/columns.ts
+++ b/back/src/registryV2/columns.ts
@@ -142,6 +142,9 @@ const formatStatusLabel = (status: string | null, opts: formatOptions) => {
   return _formatStatusLabel(status, opts.waste);
 };
 
+const QUANTITY_WITH_PACKAGING_LABEL =
+  "Nombre d'unité(s) - Conditionnement associé";
+
 export const EXPORT_COLUMNS: {
   SSD: Omit<Record<keyof SsdWasteV2, columnInfos>, "id" | "__typename">;
   INCOMING: Omit<
@@ -229,7 +232,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
+    quantity: { label: QUANTITY_WITH_PACKAGING_LABEL },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -527,7 +530,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
+    quantity: { label: QUANTITY_WITH_PACKAGING_LABEL },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -894,7 +897,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
+    quantity: { label: QUANTITY_WITH_PACKAGING_LABEL },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -1146,7 +1149,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
+    quantity: { label: QUANTITY_WITH_PACKAGING_LABEL },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -1506,7 +1509,7 @@ export const EXHAUSTIVE_EXPORT_COLUMNS = {
   wasteCode: { label: "Code déchet" },
   wastePop: { label: "POP", format: formatBoolean },
   wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-  quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
+  quantity: { label: QUANTITY_WITH_PACKAGING_LABEL },
   wasteContainsElectricOrHybridVehicles: {
     label: "VHU électrique ou hybride",
     format: formatBoolean

--- a/back/src/registryV2/columns.ts
+++ b/back/src/registryV2/columns.ts
@@ -47,7 +47,6 @@ const formatEmitterType = (emitterType: EmitterType | null) => {
 };
 const formatNumber = (n: number) =>
   isDefined(n) ? parseFloat(n.toFixed(3)) : null; // return as a number to allow xls cells formulas
-const formatInteger = (n: number) => (isDefined(n) ? Math.round(n) : null);
 const formatArray = (arr: any[], opts = { separator: "," }) =>
   Array.isArray(arr) ? arr.join(opts.separator) : "";
 const formatArrayWithMissingElements = (arr: any[]) => {
@@ -230,7 +229,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s)", format: formatInteger },
+    quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -528,7 +527,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s)", format: formatInteger },
+    quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -895,7 +894,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s)", format: formatInteger },
+    quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -1147,7 +1146,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s)", format: formatInteger },
+    quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -1507,7 +1506,7 @@ export const EXHAUSTIVE_EXPORT_COLUMNS = {
   wasteCode: { label: "Code déchet" },
   wastePop: { label: "POP", format: formatBoolean },
   wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-  quantity: { label: "Nombre d'unité(s)", format: formatInteger },
+  quantity: { label: "Nombre d'unité(s) - Conditionnement associé" },
   wasteContainsElectricOrHybridVehicles: {
     label: "VHU électrique ou hybride",
     format: formatBoolean

--- a/back/src/registryV2/packagings.ts
+++ b/back/src/registryV2/packagings.ts
@@ -1,0 +1,97 @@
+type PackagingLike = {
+  type: string;
+  quantity?: number | null;
+  other?: string | null;
+};
+
+export const BSDA_PACKAGING_LABELS: Record<string, string> = {
+  BIG_BAG: "Big-bag / GRV",
+  DEPOT_BAG: "Dépôt-bag",
+  PALETTE_FILME: "Palette filmée",
+  SAC_RENFORCE: "Sac renforcé",
+  CONTENEUR_BAG: "Conteneur-bag",
+  OTHER: "Autre"
+};
+
+export const BSDASRI_PACKAGING_LABELS: Record<string, string> = {
+  BOITE_CARTON: "Caisse(s) en carton avec sac en plastique",
+  FUT: "Fût(s)",
+  BOITE_PERFORANTS: "Boîte(s) et Mini-collecteurs pour déchets perforants",
+  GRAND_EMBALLAGE: "Grand(s) emballage(s)",
+  GRV: "Grand(s) récipient(s) pour vrac",
+  AUTRE: "Autre(s)"
+};
+
+export const BSFF_PACKAGING_LABELS: Record<string, string> = {
+  BOUTEILLE: "Bouteille",
+  CITERNE: "Citerne",
+  CONTENEUR: "Conteneur",
+  AUTRE: "Autre"
+};
+
+export const BSPAOH_PACKAGING_LABELS: Record<string, string> = {
+  RELIQUAIRE: "Reliquaire",
+  LITTLE_BOX: "Petite boîte",
+  BIG_BOX: "Grande boîte"
+};
+
+export const BSVHU_PACKAGING_LABELS: Record<string, string> = {
+  UNITE: "unités",
+  LOT: "lots"
+};
+
+export const BSDD_PACKAGING_LABELS: Record<string, string> = {
+  FUT: "Fût",
+  GRV: "Grand Récipient Vrac (GRV)",
+  CITERNE: "Citerne",
+  BENNE: "Benne",
+  PIPELINE: "Conditionné pour pipeline",
+  AUTRE: "Autre"
+};
+
+export function formatGroupedPackagingQuantity(
+  packagings: PackagingLike[] | null | undefined,
+  labels: Record<string, string>,
+  options?: {
+    otherType?: string;
+    useQuantityField?: boolean;
+  }
+) {
+  if (!packagings?.length) {
+    return null;
+  }
+
+  const otherType = options?.otherType ?? "AUTRE";
+  const grouped = new Map<string, number>();
+
+  for (const packaging of packagings) {
+    const baseLabel = labels[packaging.type] ?? packaging.type;
+
+    const type =
+      packaging.type === otherType
+        ? `${baseLabel}${packaging.other ? ` (${packaging.other})` : ""}`
+        : baseLabel;
+
+    const quantity = options?.useQuantityField ? packaging.quantity ?? 0 : 1;
+
+    grouped.set(type, (grouped.get(type) ?? 0) + quantity);
+  }
+
+  return [...grouped.entries()]
+    .map(([type, quantity]) => `${quantity}: ${type}`)
+    .join(" | ");
+}
+
+export function formatSinglePackagingQuantity(
+  quantity: number | null | undefined,
+  packaging: string | null | undefined,
+  labels: Record<string, string>
+) {
+  if (quantity == null) {
+    return null;
+  }
+
+  const label = packaging ? labels[packaging] ?? packaging : "";
+
+  return label ? `${quantity}: ${label}` : `${quantity}`;
+}

--- a/back/src/registryV2/typeDefs/registryV2.objects.exports.graphql
+++ b/back/src/registryV2/typeDefs/registryV2.objects.exports.graphql
@@ -56,9 +56,9 @@ type IncomingWasteV2 {
   wasteIsDangerous: Boolean
 
   """
-  Quantité de déchet en unités
+  Quantité de déchet en string
   """
-  quantity: Int
+  quantity: String
 
   """
   Est-ce que le déchet contient des véhicules électriques ou hybrides ?
@@ -435,9 +435,9 @@ type OutgoingWasteV2 {
   weight: Float
 
   """
-  Quantité de déchet en unités
+  Quantité de déchet en string
   """
-  quantity: Int
+  quantity: String
 
   """
   Est-ce que le déchet contient des véhicules électriques ou hybrides ?
@@ -843,9 +843,9 @@ type TransportedWasteV2 {
   weight: Float
 
   """
-  Quantité de déchet en unités
+  Quantité de déchet en String
   """
-  quantity: Int
+  quantity: String
 
   """
   Est-ce que le déchet contient des véhicules électriques ou hybrides ?
@@ -1179,9 +1179,9 @@ type ManagedWasteV2 {
   weight: Float
 
   """
-  Quantité de déchet en unités
+  Quantité de déchet en String
   """
-  quantity: Int
+  quantity: String
 
   """
   Est-ce que le déchet contient des véhicules électriques ou hybrides ?
@@ -1580,9 +1580,9 @@ type AllWasteV2 {
   wasteIsDangerous: Boolean
 
   """
-  Quantité de déchet en unités
+  Quantité de déchet en String
   """
-  quantity: Int
+  quantity: String
 
   """
   Est-ce que le déchet contient des véhicules électriques ou hybrides ?

--- a/back/src/registryV2/utils.ts
+++ b/back/src/registryV2/utils.ts
@@ -1,7 +1,12 @@
 import { Prisma } from "@td/prisma";
 import { prisma } from "@td/prisma";
 import { GenericWasteV2 } from "./types";
-import { IncomingWasteV2, OutgoingWasteV2, SsdWasteV2 } from "@td/codegen-back";
+import {
+  IncomingWasteV2,
+  OutgoingWasteV2,
+  SsdWasteV2,
+  PackagingInfo
+} from "@td/codegen-back";
 
 type CompanyCache = {
   [siret: string]: Prisma.CompanyGetPayload<{
@@ -95,3 +100,12 @@ export class CompanyCachedFetcher {
     return registryWaste;
   }
 }
+
+export const packagingLabels: Record<PackagingInfo["type"], string> = {
+  FUT: "Fût",
+  GRV: "Grand Récipient Vrac (GRV)",
+  CITERNE: "Citerne",
+  BENNE: "Benne",
+  PIPELINE: "Conditionné pour pipeline",
+  AUTRE: "Autre"
+};


### PR DESCRIPTION
# Contexte

 Registre exhaustif  : Ajouter dans la colonne  "Nombre d'unités"  (Nombre, Type ) des conditionnements pour tous les bordereaux

# Points de vigilance pour les intégrateurs



# Démo


https://github.com/user-attachments/assets/41737748-940b-4e58-973a-fab004579dc3

[TD-Registre-20260706-Exhaustif.csv](https://github.com/user-attachments/files/29705986/TD-Registre-20260706-Exhaustif.csv)


# Ticket Favro

[Trackdéchets & Registre exhaustif  : Ajouter Conditionnement : (Nombre, Type et Volume) ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13187)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB