### PR TITLE
Tra 18500: MFA - Activer la double authentification - Révisions des codes

### DIFF
--- a/back/src/users/resolvers/mutations/__tests__/confirmTotpSetup.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/confirmTotpSetup.integration.ts
@@ -88,3 +88,43 @@ describe("Mutation.confirmTotpSetup — MFA audit log", () => {
     expect(count).toBe(0);
   });
 });
+
+describe("Mutation.confirmTotpSetup — recovery codes format", () => {
+  afterAll(resetDatabase);
+
+  it("generates exactly 5 recovery codes of 20 alphanumeric characters formatted as 4 groups of 5", async () => {
+    const user = await userFactory({ totpSeed: SEED });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    const { otp } = TOTP.generate(SEED);
+    const { data, errors } = await mutate<Pick<Mutation, "confirmTotpSetup">>(
+      CONFIRM_TOTP_SETUP,
+      {
+        variables: { code: otp }
+      }
+    );
+    expect(errors).toBeUndefined();
+
+    const codes = data!.confirmTotpSetup.codes;
+    expect(codes).toHaveLength(5);
+
+    const codePattern = /^[A-Z0-9]{5}-[A-Z0-9]{5}-[A-Z0-9]{5}-[A-Z0-9]{5}$/;
+    codes.forEach(code => {
+      expect(code).toMatch(codePattern);
+      expect(code.replace(/-/g, "")).toHaveLength(20);
+    });
+
+    // all codes must be unique
+    expect(new Set(codes).size).toBe(5);
+
+    // codes must only be stored as bcrypt hashes, never in clear
+    const storedCodes = await prisma.totpRecoveryCode.findMany({
+      where: { userId: user.id }
+    });
+    expect(storedCodes).toHaveLength(5);
+    storedCodes.forEach(stored => {
+      expect(codes).not.toContain(stored.codeHash);
+      expect(stored.codeHash.startsWith("$2b$")).toBe(true);
+    });
+  });
+});

--- a/back/src/users/resolvers/mutations/confirmTotpSetup.ts
+++ b/back/src/users/resolvers/mutations/confirmTotpSetup.ts
@@ -10,34 +10,40 @@ import { sendMail } from "../../../mailer/mailing";
 import { onTotpActivated, renderMail } from "@td/mail";
 import { logMfaEvent } from "../../../common/mfaLogger";
 
-const RECOVERY_CODE_COUNT = 10;
+const RECOVERY_CODE_COUNT = 5;
+const RECOVERY_CODE_LENGTH = 20;
+const RECOVERY_CODE_GROUP_SIZE = 5;
 const RECOVERY_CODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 const BCRYPT_SALT_ROUNDS = 10;
 
 /**
- * Génère un code de récupération aléatoire au format XXXXX-XXXXX.
- * La saisie est insensible à la casse et le tiret est ignoré à la validation.
+ * Génère un code de récupération aléatoire au format XXXXX-XXXXX-XXXXX-XXXXX.
+ * La saisie est insensible à la casse et les tirets sont ignorés à la validation.
  */
 function generateRecoveryCode(): string {
   const charsetLength = RECOVERY_CODE_CHARS.length;
   const maxUnbiased = Math.floor(256 / charsetLength) * charsetLength;
   const chars: string[] = [];
 
-  while (chars.length < 10) {
-    const bytes = randomBytes(10 - chars.length);
+  while (chars.length < RECOVERY_CODE_LENGTH) {
+    const bytes = randomBytes(RECOVERY_CODE_LENGTH - chars.length);
     for (const b of bytes) {
       if (b >= maxUnbiased) {
         continue;
       }
       chars.push(RECOVERY_CODE_CHARS[b % charsetLength]);
-      if (chars.length === 10) {
+      if (chars.length === RECOVERY_CODE_LENGTH) {
         break;
       }
     }
   }
 
   const raw = chars.join("");
-  return `${raw.slice(0, 5)}-${raw.slice(5, 10)}`;
+  const groups: string[] = [];
+  for (let i = 0; i < raw.length; i += RECOVERY_CODE_GROUP_SIZE) {
+    groups.push(raw.slice(i, i + RECOVERY_CODE_GROUP_SIZE));
+  }
+  return groups.join("-");
 }
 
 /**

--- a/back/src/users/services/__tests__/recoveryCode.service.integration.ts
+++ b/back/src/users/services/__tests__/recoveryCode.service.integration.ts
@@ -1,0 +1,43 @@
+import { hash } from "bcrypt";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { prisma } from "@td/prisma";
+import { userFactory } from "../../../__tests__/factories";
+import { findValidRecoveryCode } from "../recoveryCode.service";
+
+describe("findValidRecoveryCode", () => {
+  afterEach(resetDatabase);
+
+  it("matches a 20-character / 4-group recovery code regardless of dashes or case", async () => {
+    const plainCode = "ABCDE-FGHIJ-KLMNO-PQRST";
+    const normalized = plainCode.replace(/-/g, "").toUpperCase();
+    const codeHash = await hash(normalized, 10);
+
+    const user = await userFactory();
+    const recoveryCode = await prisma.totpRecoveryCode.create({
+      data: { userId: user.id, codeHash }
+    });
+
+    // with dashes, uppercase
+    expect(await findValidRecoveryCode(user.id, plainCode)).toBe(
+      recoveryCode.id
+    );
+    // without dashes, lowercase
+    expect(await findValidRecoveryCode(user.id, normalized.toLowerCase())).toBe(
+      recoveryCode.id
+    );
+  });
+
+  it("returns null when the code does not match any stored hash", async () => {
+    const user = await userFactory();
+    await prisma.totpRecoveryCode.create({
+      data: {
+        userId: user.id,
+        codeHash: await hash("AAAAABBBBBCCCCCDDDDD", 10)
+      }
+    });
+
+    expect(
+      await findValidRecoveryCode(user.id, "ZZZZZ-ZZZZZ-ZZZZZ-ZZZZZ")
+    ).toBeNull();
+  });
+});

--- a/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
@@ -403,7 +403,7 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
                 borderRadius: 4,
                 fontFamily: "monospace",
                 display: "grid",
-                gridTemplateColumns: "1fr 1fr",
+                gridTemplateColumns: "1fr",
                 gap: "0.5rem"
               }}
             >

--- a/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
@@ -201,21 +201,52 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
       {step === "explanation" && (
         <div>
           <p className="fr-mb-3w">
-            Un code unique vous sera demandé à chaque nouvelle session. Pour
-            l'obtenir, vous devez utiliser une application mobile.
+            Pour renforcer la sécurité de votre compte, un code à usage unique
+            vous sera demandé à chaque connexion. Pour générer ce code, vous
+            devrez utiliser une application d'authentification compatible TOTP,
+            installée sur votre téléphone.
           </p>
           <p className="fr-mb-3w">
-            Si vous n'avez pas encore d'application, nous vous conseillons
-            d'utiliser l'outil opensource{" "}
+            Si vous n'en utilisez pas déjà une, vous pouvez installer l'une des
+            applications suivantes :{" "}
             <a
               href="https://freeotp.github.io/"
               target="_blank"
               rel="noopener noreferrer"
               className="fr-link"
             >
-              FreeOTP Authenticator
+              FreeOTP
             </a>
-            .
+            <p>
+              <a
+                href="https://2fas.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="fr-link"
+              >
+                2FAS
+              </a>
+            </p>
+            <p>
+              <a
+                href="https://support.google.com/accounts/answer/1066447"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="fr-link"
+              >
+                Google Authenticator
+              </a>
+            </p>
+            <p>
+              <a
+                href="https://support.microsoft.com/en-us/authenticator/download-microsoft-authenticator"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="fr-link"
+              >
+                Microsoft Authenticator
+              </a>
+            </p>
           </p>
 
           {generateError && (
@@ -243,8 +274,9 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             </label>
             {showAppError && (
               <p className="fr-error-text">
-                Merci de bien vouloir prendre connaissance et cocher la case
-                pour continuer.
+                Il est nécessaire d'installer une application d'authentification
+                TOTP pour passer à l'étape suivante de mise en place de
+                l'authentification multifactorielle.
               </p>
             )}
           </div>
@@ -269,7 +301,7 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
         <div>
           <h3 className="fr-h1">
             <p className="fr-text--lead">
-              Scannez ce QRcode avec votre application
+              Scannez ce QRCode avec votre application d'authentification.
             </p>
           </h3>
 
@@ -311,9 +343,9 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             </div>
           )}
 
-          <div className="fr-col-md-8">
+          <div className="fr-col-md-9">
             <label className="fr-label fr-text--bold fr-²">
-              Insérez le code généré par votre application
+              Insérez le code généré par votre application d'authentification
             </label>
             <Input
               label="Entrez le code à usage unique"
@@ -427,8 +459,9 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             </label>
             {showSavedError && (
               <p className="fr-error-text">
-                Merci de bien vouloir prendre connaissance et cocher la case
-                pour continuer.
+                Il est indispensable de sauvegarder vos clés de récupération
+                sans cela, en cas de perte de votre téléphone, vous ne pourrez
+                plus accéder à votre compte.
               </p>
             )}
           </div>

--- a/front/src/login/RecoveryCodeModal.tsx
+++ b/front/src/login/RecoveryCodeModal.tsx
@@ -99,7 +99,7 @@ export default function RecoveryCodeModal({
             name: "recoveryCode",
             value: code,
             autoComplete: "off",
-            placeholder: "Ex : ABCDE-FGHIJ",
+            placeholder: "Ex : ABCDE-FGHIJ-KLMNO-PQRST",
             onChange: e => setCode(e.target.value),
             disabled: isLockout
           }}


### PR DESCRIPTION
# Contexte

L’objectif est d’ajuster le format et le nombre de ces codes sans modifier le fonctionnement global existant. Désormais, l’utilisateur doit recevoir 5 codes de récupération de 20 caractères, affichés avec des tirets pour faciliter la lecture, tout en conservant les règles de sécurité déjà définies.


# Démo

<img width="838" height="732" alt="image" src="https://github.com/user-attachments/assets/d2344901-f9ea-4bc8-8f22-c8c848baa8da" />

# Ticket Favro

[MFA - Activer la double authentification - Révisions des codes](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-18500)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB