### PR TITLE
Tra 18499: MFA - Récupérer son compte via un code de récupération - Evolutions

### DIFF
--- a/back/src/__tests__/recoveryLogin.integration.ts
+++ b/back/src/__tests__/recoveryLogin.integration.ts
@@ -165,10 +165,36 @@ describe("POST /recovery-login", () => {
     });
     expect(updatedUser.recoveryFails).toBe(3);
     expect(updatedUser.recoveryLockedUntil).not.toBeNull();
-    // lockout must be ~5 minutes from now
+    // lockout must be ~1h from now
     expect(
-      updatedUser.recoveryLockedUntil!.getTime() - before.getTime() >= 300_000
+      updatedUser.recoveryLockedUntil!.getTime() - before.getTime() >= 3_600_000
     ).toBe(true);
+  });
+
+  it("returns attemptsRemaining=2 on the 1st invalid attempt", async () => {
+    const { user } = await createUserWithRecoveryCode();
+    const cookie = await doLogin(user.email);
+
+    const res = await request
+      .post("/recovery-login")
+      .send("recoveryCode=WRONG-CODE")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.header.location).toContain("attemptsRemaining=2");
+  });
+
+  it("returns attemptsRemaining=1 on the 2nd invalid attempt", async () => {
+    const { user } = await createUserWithRecoveryCode("ABCDE-FGHIJ", {
+      recoveryFails: 1
+    });
+    const cookie = await doLogin(user.email);
+
+    const res = await request
+      .post("/recovery-login")
+      .send("recoveryCode=WRONG-CODE")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.header.location).toContain("attemptsRemaining=1");
   });
 
   it("blocks any attempt during an active lockout", async () => {
@@ -216,6 +242,96 @@ describe("POST /recovery-login", () => {
     const newCookieValue = newCookieHeader?.match(cookieRegExp)?.[1];
     expect(newCookieValue).toBeDefined();
     expect(newCookieValue).not.toBe(cookie);
+  });
+
+  it("recoveryAction=TEMPORARY with remaining codes: connects normally without resetting TOTP", async () => {
+    const { user, plainCode } = await createUserWithRecoveryCode();
+    // Second valid recovery code so at least one remains after consumption
+    await prisma.totpRecoveryCode.create({
+      data: { userId: user.id, codeHash: await hash("OTHERCODE", 10) }
+    });
+    const cookie = await doLogin(user.email);
+
+    const res = await request
+      .post("/recovery-login")
+      .send(`recoveryCode=${plainCode}`)
+      .send("recoveryAction=TEMPORARY")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe(`http://${UI_HOST}/`);
+
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    // TOTP must remain intact
+    expect(updatedUser.totpSeed).not.toBeNull();
+    expect(updatedUser.mustReconfigureMfa).toBe(false);
+    expect(updatedUser.recoveryFails).toBe(0);
+    expect(updatedUser.recoveryLockedUntil).toBeNull();
+
+    // The used code is marked as used, the other one remains valid
+    const codes = await prisma.totpRecoveryCode.findMany({
+      where: { userId: user.id }
+    });
+    expect(codes).toHaveLength(2);
+    const usedCodes = codes.filter(c => c.usedAt !== null);
+    const validCodes = codes.filter(c => c.usedAt === null);
+    expect(usedCodes).toHaveLength(1);
+    expect(validCodes).toHaveLength(1);
+  });
+
+  it("recoveryAction=TEMPORARY on the last valid code falls back to a full MFA reset", async () => {
+    const { user, plainCode } = await createUserWithRecoveryCode();
+    const cookie = await doLogin(user.email);
+
+    const res = await request
+      .post("/recovery-login")
+      .send(`recoveryCode=${plainCode}`)
+      .send("recoveryAction=TEMPORARY")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.status).toBe(302);
+    expect(res.header.location).toBe(`http://${UI_HOST}/`);
+
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    expect(updatedUser.totpSeed).toBeNull();
+    expect(updatedUser.totpActivatedAt).toBeNull();
+    expect(updatedUser.mustReconfigureMfa).toBe(true);
+
+    const remainingCodes = await prisma.totpRecoveryCode.findMany({
+      where: { userId: user.id }
+    });
+    expect(remainingCodes).toHaveLength(0);
+  });
+
+  it("recoveryAction=RESET revokes TOTP even if other codes remain valid", async () => {
+    const { user, plainCode } = await createUserWithRecoveryCode();
+    await prisma.totpRecoveryCode.create({
+      data: { userId: user.id, codeHash: await hash("OTHERCODE", 10) }
+    });
+    const cookie = await doLogin(user.email);
+
+    const res = await request
+      .post("/recovery-login")
+      .send(`recoveryCode=${plainCode}`)
+      .send("recoveryAction=RESET")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    expect(res.status).toBe(302);
+
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+    expect(updatedUser.totpSeed).toBeNull();
+    expect(updatedUser.mustReconfigureMfa).toBe(true);
+
+    const remainingCodes = await prisma.totpRecoveryCode.findMany({
+      where: { userId: user.id }
+    });
+    expect(remainingCodes).toHaveLength(0);
   });
 
   it("rejects a code that has already been deleted (already used)", async () => {
@@ -350,6 +466,47 @@ describe("POST /recovery-login", () => {
       where: { userId: user.id, eventType: "MFA_RECOVERY_LOCKOUT_LIFTED" }
     });
     expect(liftedLog).toBeNull();
+  });
+
+  it("log MFA_RECOVERY_TEMP_LOGIN_SUCCESS écrit lors d'une connexion temporaire avec codes restants", async () => {
+    const { user, plainCode } = await createUserWithRecoveryCode();
+    await prisma.totpRecoveryCode.create({
+      data: { userId: user.id, codeHash: await hash("OTHERCODE", 10) }
+    });
+    const cookie = await doLogin(user.email);
+
+    await request
+      .post("/recovery-login")
+      .send(`recoveryCode=${plainCode}`)
+      .send("recoveryAction=TEMPORARY")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    await flushAuditLog();
+
+    const log = await prisma.mfaAuditLog.findFirst({
+      where: { userId: user.id, eventType: "MFA_RECOVERY_TEMP_LOGIN_SUCCESS" }
+    });
+    expect(log).not.toBeNull();
+    expect(log!.success).toBe(true);
+  });
+
+  it("log MFA_RECOVERY_LAST_CODE_USED écrit quand le dernier code déclenche un reset en mode TEMPORARY", async () => {
+    const { user, plainCode } = await createUserWithRecoveryCode();
+    const cookie = await doLogin(user.email);
+
+    await request
+      .post("/recovery-login")
+      .send(`recoveryCode=${plainCode}`)
+      .send("recoveryAction=TEMPORARY")
+      .set("Cookie", `${sess.name}=${cookie}`);
+
+    await flushAuditLog();
+
+    const log = await prisma.mfaAuditLog.findFirst({
+      where: { userId: user.id, eventType: "MFA_RECOVERY_LAST_CODE_USED" }
+    });
+    expect(log).not.toBeNull();
+    expect(log!.success).toBe(true);
   });
 
   it("logs MFA recovery : aucun code TOTP, code de récupération ou mot de passe stocké", async () => {

--- a/back/src/auth/recoveryLoginHandler.ts
+++ b/back/src/auth/recoveryLoginHandler.ts
@@ -3,13 +3,22 @@ import { prisma, User } from "@td/prisma";
 import { addSeconds } from "date-fns";
 import { sanitizeEmail, getUIBaseURL } from "../utils";
 import { getSafeReturnTo } from "../common/helpers";
-import { findValidRecoveryCode } from "../users/services/recoveryCode.service";
+import {
+  findValidRecoveryCode,
+  countValidRecoveryCodes
+} from "../users/services/recoveryCode.service";
 import { AuthType } from "./auth";
 import { logMfaEvent } from "../common/mfaLogger";
 
 const UI_BASE_URL = getUIBaseURL();
 const RECOVERY_MAX_FAILS = 3;
-const RECOVERY_LOCK_SECONDS = 300; // 5 minutes, cohérent avec le lockout TOTP
+const RECOVERY_LOCK_SECONDS = 3600; // 1h
+
+type RecoveryAction = "RESET" | "TEMPORARY";
+
+function parseRecoveryAction(raw: unknown): RecoveryAction {
+  return raw === "TEMPORARY" ? "TEMPORARY" : "RESET";
+}
 
 async function increaseRecoveryLock(
   user: User
@@ -32,14 +41,15 @@ async function increaseRecoveryLock(
  * Valide un code de récupération soumis depuis la modale "Je n'ai pas accès à
  * l'application". Requiert une session preloggedUser valide (même prérequis que /otp).
  *
- * En cas de succès :
- *  - tous les codes de récupération de l'utilisateur sont invalidés
- *  - le secret TOTP est révoqué
- *  - mustReconfigureMfa est mis à true
- *  - l'utilisateur est connecté
- *  - l'email de récupération est envoyé en fin de reconfiguration (finalizeMfaSetup)
+ * Deux comportements possibles selon `recoveryAction` :
+ *  - RESET : tous les codes de récupération sont invalidés, le secret TOTP est
+ *    révoqué, mustReconfigureMfa est mis à true, l'utilisateur est connecté.
+ *  - TEMPORARY : seul le code soumis est consommé. S'il reste au moins un
+ *    autre code valide, l'utilisateur est connecté normalement (TOTP et
+ *    autres codes intacts). Si c'était le dernier code valide, le comportement
+ *    retombe sur RESET.
  *
- * Lockout : RECOVERY_MAX_FAILS (3) tentatives invalides → blocage RECOVERY_LOCK_SECONDS (300s)
+ * Lockout : RECOVERY_MAX_FAILS (3) tentatives invalides → blocage RECOVERY_LOCK_SECONDS (1h)
  */
 export async function recoveryLoginHandler(
   req: Request,
@@ -48,6 +58,7 @@ export async function recoveryLoginHandler(
 ): Promise<void> {
   try {
     const { recoveryCode } = req.body;
+    const recoveryAction = parseRecoveryAction(req.body.recoveryAction);
     const returnTo = getSafeReturnTo(req.body.returnTo, UI_BASE_URL);
 
     const userEmail = req.session?.preloggedUser?.userEmail;
@@ -108,6 +119,7 @@ export async function recoveryLoginHandler(
           `${UI_BASE_URL}/second-factor?errorCode=RECOVERY_LOCKOUT&lockout=${recoveryLockedUntil!.getTime()}`
         );
       } else {
+        const attemptsRemaining = RECOVERY_MAX_FAILS - recoveryFails;
         logMfaEvent({
           eventType: "MFA_RECOVERY_FAILURE",
           userId: user.id,
@@ -115,7 +127,7 @@ export async function recoveryLoginHandler(
           ip: req.ip
         });
         res.redirect(
-          `${UI_BASE_URL}/second-factor?errorCode=INVALID_RECOVERY_CODE`
+          `${UI_BASE_URL}/second-factor?errorCode=INVALID_RECOVERY_CODE&attemptsRemaining=${attemptsRemaining}`
         );
       }
       return;
@@ -124,24 +136,64 @@ export async function recoveryLoginHandler(
     // Capture avant la transaction (qui remet recoveryLockedUntil à null)
     const wasLocked = !!user.recoveryLockedUntil;
 
-    // Code valide : révocation complète TOTP + activation flag reconfiguration
-    await prisma.$transaction([
-      // Invalide tous les codes (y compris le code utilisé — pas d'audit trail nécessaire)
-      prisma.totpRecoveryCode.deleteMany({ where: { userId: user.id } }),
-      // Révoque le TOTP, remet les compteurs à zéro, active la reconfiguration forcée
-      prisma.user.update({
-        where: { id: user.id },
-        data: {
-          totpSeed: null,
-          totpActivatedAt: null,
-          totpFails: 0,
-          totpLockedUntil: null,
-          recoveryFails: 0,
-          recoveryLockedUntil: null,
-          mustReconfigureMfa: true
-        }
-      })
-    ]);
+    // Détermine si, en mode TEMPORARY, il restera au moins un autre code valide
+    const remainingOtherCodes =
+      recoveryAction === "TEMPORARY"
+        ? (await countValidRecoveryCodes(user.id)) - 1
+        : 0;
+    const shouldResetMfa =
+      recoveryAction === "RESET" || remainingOtherCodes <= 0;
+
+    if (shouldResetMfa) {
+      // Révocation complète TOTP + activation flag reconfiguration
+      await prisma.$transaction([
+        // Invalide tous les codes (y compris le code utilisé — pas d'audit trail nécessaire)
+        prisma.totpRecoveryCode.deleteMany({ where: { userId: user.id } }),
+        prisma.user.update({
+          where: { id: user.id },
+          data: {
+            totpSeed: null,
+            totpActivatedAt: null,
+            totpFails: 0,
+            totpLockedUntil: null,
+            recoveryFails: 0,
+            recoveryLockedUntil: null,
+            mustReconfigureMfa: true
+          }
+        })
+      ]);
+
+      if (recoveryAction === "TEMPORARY") {
+        logMfaEvent({
+          eventType: "MFA_RECOVERY_LAST_CODE_USED",
+          userId: user.id,
+          success: true,
+          ip: req.ip
+        });
+      }
+    } else {
+      // Connexion temporaire unique : seul le code soumis est consommé
+      await prisma.$transaction([
+        prisma.totpRecoveryCode.update({
+          where: { id: recoveryCodeId },
+          data: { usedAt: new Date() }
+        }),
+        prisma.user.update({
+          where: { id: user.id },
+          data: {
+            recoveryFails: 0,
+            recoveryLockedUntil: null
+          }
+        })
+      ]);
+
+      logMfaEvent({
+        eventType: "MFA_RECOVERY_TEMP_LOGIN_SUCCESS",
+        userId: user.id,
+        success: true,
+        ip: req.ip
+      });
+    }
 
     if (wasLocked) {
       logMfaEvent({

--- a/back/src/common/mfaLogger.ts
+++ b/back/src/common/mfaLogger.ts
@@ -16,7 +16,9 @@ export type MfaEventType =
   | "MFA_RECOVERY_LOCKOUT_LIFTED"
   | "MFA_MANUAL_RESET_INITIATED"
   | "MFA_MANUAL_RESET_BY_SUPPORT"
-  | "MFA_RECONFIG_COMPLETED";
+  | "MFA_RECONFIG_COMPLETED"
+  | "MFA_RECOVERY_TEMP_LOGIN_SUCCESS"
+  | "MFA_RECOVERY_LAST_CODE_USED";
 
 // Switch over string literals so CodeQL sees no taint flow from eventType to the return value.
 function toSafeMfaEventLabel(eventType: MfaEventType): string {
@@ -51,6 +53,10 @@ function toSafeMfaEventLabel(eventType: MfaEventType): string {
       return "MFA_MANUAL_RESET_BY_SUPPORT";
     case "MFA_RECONFIG_COMPLETED":
       return "MFA_RECONFIG_COMPLETED";
+    case "MFA_RECOVERY_TEMP_LOGIN_SUCCESS":
+      return "MFA_RECOVERY_TEMP_LOGIN_SUCCESS";
+    case "MFA_RECOVERY_LAST_CODE_USED":
+      return "MFA_RECOVERY_LAST_CODE_USED";
     default:
       return "UNKNOWN_MFA_EVENT";
   }

--- a/back/src/users/resolvers/mutations/__tests__/confirmTotpSetup.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/confirmTotpSetup.integration.ts
@@ -88,3 +88,43 @@ describe("Mutation.confirmTotpSetup — MFA audit log", () => {
     expect(count).toBe(0);
   });
 });
+
+describe("Mutation.confirmTotpSetup — recovery codes format", () => {
+  afterAll(resetDatabase);
+
+  it("generates exactly 5 recovery codes of 20 alphanumeric characters formatted as 4 groups of 5", async () => {
+    const user = await userFactory({ totpSeed: SEED });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    const { otp } = TOTP.generate(SEED);
+    const { data, errors } = await mutate<Pick<Mutation, "confirmTotpSetup">>(
+      CONFIRM_TOTP_SETUP,
+      {
+        variables: { code: otp }
+      }
+    );
+    expect(errors).toBeUndefined();
+
+    const codes = data!.confirmTotpSetup.codes;
+    expect(codes).toHaveLength(5);
+
+    const codePattern = /^[A-Z0-9]{5}-[A-Z0-9]{5}-[A-Z0-9]{5}-[A-Z0-9]{5}$/;
+    codes.forEach(code => {
+      expect(code).toMatch(codePattern);
+      expect(code.replace(/-/g, "")).toHaveLength(20);
+    });
+
+    // all codes must be unique
+    expect(new Set(codes).size).toBe(5);
+
+    // codes must only be stored as bcrypt hashes, never in clear
+    const storedCodes = await prisma.totpRecoveryCode.findMany({
+      where: { userId: user.id }
+    });
+    expect(storedCodes).toHaveLength(5);
+    storedCodes.forEach(stored => {
+      expect(codes).not.toContain(stored.codeHash);
+      expect(stored.codeHash.startsWith("$2b$")).toBe(true);
+    });
+  });
+});

--- a/back/src/users/resolvers/mutations/confirmTotpSetup.ts
+++ b/back/src/users/resolvers/mutations/confirmTotpSetup.ts
@@ -10,34 +10,40 @@ import { sendMail } from "../../../mailer/mailing";
 import { onTotpActivated, renderMail } from "@td/mail";
 import { logMfaEvent } from "../../../common/mfaLogger";
 
-const RECOVERY_CODE_COUNT = 10;
+const RECOVERY_CODE_COUNT = 5;
+const RECOVERY_CODE_LENGTH = 20;
+const RECOVERY_CODE_GROUP_SIZE = 5;
 const RECOVERY_CODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 const BCRYPT_SALT_ROUNDS = 10;
 
 /**
- * Génère un code de récupération aléatoire au format XXXXX-XXXXX.
- * La saisie est insensible à la casse et le tiret est ignoré à la validation.
+ * Génère un code de récupération aléatoire au format XXXXX-XXXXX-XXXXX-XXXXX.
+ * La saisie est insensible à la casse et les tirets sont ignorés à la validation.
  */
 function generateRecoveryCode(): string {
   const charsetLength = RECOVERY_CODE_CHARS.length;
   const maxUnbiased = Math.floor(256 / charsetLength) * charsetLength;
   const chars: string[] = [];
 
-  while (chars.length < 10) {
-    const bytes = randomBytes(10 - chars.length);
+  while (chars.length < RECOVERY_CODE_LENGTH) {
+    const bytes = randomBytes(RECOVERY_CODE_LENGTH - chars.length);
     for (const b of bytes) {
       if (b >= maxUnbiased) {
         continue;
       }
       chars.push(RECOVERY_CODE_CHARS[b % charsetLength]);
-      if (chars.length === 10) {
+      if (chars.length === RECOVERY_CODE_LENGTH) {
         break;
       }
     }
   }
 
   const raw = chars.join("");
-  return `${raw.slice(0, 5)}-${raw.slice(5, 10)}`;
+  const groups: string[] = [];
+  for (let i = 0; i < raw.length; i += RECOVERY_CODE_GROUP_SIZE) {
+    groups.push(raw.slice(i, i + RECOVERY_CODE_GROUP_SIZE));
+  }
+  return groups.join("-");
 }
 
 /**

--- a/back/src/users/services/__tests__/recoveryCode.service.integration.ts
+++ b/back/src/users/services/__tests__/recoveryCode.service.integration.ts
@@ -22,9 +22,9 @@ describe("findValidRecoveryCode", () => {
       recoveryCode.id
     );
     // without dashes, lowercase
-    expect(
-      await findValidRecoveryCode(user.id, normalized.toLowerCase())
-    ).toBe(recoveryCode.id);
+    expect(await findValidRecoveryCode(user.id, normalized.toLowerCase())).toBe(
+      recoveryCode.id
+    );
   });
 
   it("returns null when the code does not match any stored hash", async () => {

--- a/back/src/users/services/__tests__/recoveryCode.service.integration.ts
+++ b/back/src/users/services/__tests__/recoveryCode.service.integration.ts
@@ -1,0 +1,43 @@
+import { hash } from "bcrypt";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { prisma } from "@td/prisma";
+import { userFactory } from "../../../__tests__/factories";
+import { findValidRecoveryCode } from "../recoveryCode.service";
+
+describe("findValidRecoveryCode", () => {
+  afterEach(resetDatabase);
+
+  it("matches a 20-character / 4-group recovery code regardless of dashes or case", async () => {
+    const plainCode = "ABCDE-FGHIJ-KLMNO-PQRST";
+    const normalized = plainCode.replace(/-/g, "").toUpperCase();
+    const codeHash = await hash(normalized, 10);
+
+    const user = await userFactory();
+    const recoveryCode = await prisma.totpRecoveryCode.create({
+      data: { userId: user.id, codeHash }
+    });
+
+    // with dashes, uppercase
+    expect(await findValidRecoveryCode(user.id, plainCode)).toBe(
+      recoveryCode.id
+    );
+    // without dashes, lowercase
+    expect(
+      await findValidRecoveryCode(user.id, normalized.toLowerCase())
+    ).toBe(recoveryCode.id);
+  });
+
+  it("returns null when the code does not match any stored hash", async () => {
+    const user = await userFactory();
+    await prisma.totpRecoveryCode.create({
+      data: {
+        userId: user.id,
+        codeHash: await hash("AAAAABBBBBCCCCCDDDDD", 10)
+      }
+    });
+
+    expect(
+      await findValidRecoveryCode(user.id, "ZZZZZ-ZZZZZ-ZZZZZ-ZZZZZ")
+    ).toBeNull();
+  });
+});

--- a/back/src/users/services/recoveryCode.service.ts
+++ b/back/src/users/services/recoveryCode.service.ts
@@ -22,3 +22,12 @@ export async function findValidRecoveryCode(
   }
   return null;
 }
+
+/**
+ * Compte les codes de récupération encore valides (non utilisés) d'un utilisateur.
+ */
+export async function countValidRecoveryCodes(userId: string): Promise<number> {
+  return prisma.totpRecoveryCode.count({
+    where: { userId, usedAt: null }
+  });
+}

--- a/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
@@ -403,7 +403,7 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
                 borderRadius: 4,
                 fontFamily: "monospace",
                 display: "grid",
-                gridTemplateColumns: "1fr 1fr",
+                gridTemplateColumns: "1fr",
                 gap: "0.5rem"
               }}
             >

--- a/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
+++ b/front/src/Apps/Account/AccountAuthentication/TotpSetupWizard.tsx
@@ -201,21 +201,52 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
       {step === "explanation" && (
         <div>
           <p className="fr-mb-3w">
-            Un code unique vous sera demandé à chaque nouvelle session. Pour
-            l'obtenir, vous devez utiliser une application mobile.
+            Pour renforcer la sécurité de votre compte, un code à usage unique
+            vous sera demandé à chaque connexion. Pour générer ce code, vous
+            devrez utiliser une application d'authentification compatible TOTP,
+            installée sur votre téléphone.
           </p>
           <p className="fr-mb-3w">
-            Si vous n'avez pas encore d'application, nous vous conseillons
-            d'utiliser l'outil opensource{" "}
+            Si vous n'en utilisez pas déjà une, vous pouvez installer l'une des
+            applications suivantes :{" "}
             <a
               href="https://freeotp.github.io/"
               target="_blank"
               rel="noopener noreferrer"
               className="fr-link"
             >
-              FreeOTP Authenticator
+              FreeOTP
             </a>
-            .
+            <p>
+              <a
+                href="https://2fas.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="fr-link"
+              >
+                2FAS
+              </a>
+            </p>
+            <p>
+              <a
+                href="https://support.google.com/accounts/answer/1066447"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="fr-link"
+              >
+                Google Authenticator
+              </a>
+            </p>
+            <p>
+              <a
+                href="https://support.microsoft.com/en-us/authenticator/download-microsoft-authenticator"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="fr-link"
+              >
+                Microsoft Authenticator
+              </a>
+            </p>
           </p>
 
           {generateError && (
@@ -243,8 +274,9 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             </label>
             {showAppError && (
               <p className="fr-error-text">
-                Merci de bien vouloir prendre connaissance et cocher la case
-                pour continuer.
+                Il est nécessaire d'installer une application d'authentification
+                TOTP pour passer à l'étape suivante de mise en place de
+                l'authentification multifactorielle.
               </p>
             )}
           </div>
@@ -269,7 +301,7 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
         <div>
           <h3 className="fr-h1">
             <p className="fr-text--lead">
-              Scannez ce QRcode avec votre application
+              Scannez ce QRCode avec votre application d'authentification.
             </p>
           </h3>
 
@@ -311,9 +343,9 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             </div>
           )}
 
-          <div className="fr-col-md-8">
+          <div className="fr-col-md-9">
             <label className="fr-label fr-text--bold fr-²">
-              Insérez le code généré par votre application
+              Insérez le code généré par votre application d'authentification
             </label>
             <Input
               label="Entrez le code à usage unique"
@@ -427,8 +459,9 @@ export default function TotpSetupWizard({ onSuccess, onClose }: Props) {
             </label>
             {showSavedError && (
               <p className="fr-error-text">
-                Merci de bien vouloir prendre connaissance et cocher la case
-                pour continuer.
+                Il est indispensable de sauvegarder vos clés de récupération
+                sans cela, en cas de perte de votre téléphone, vous ne pourrez
+                plus accéder à votre compte.
               </p>
             )}
           </div>

--- a/front/src/login/RecoveryCodeModal.tsx
+++ b/front/src/login/RecoveryCodeModal.tsx
@@ -2,6 +2,7 @@ import React, { createRef, useState } from "react";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
+import { RadioButtons } from "@codegouvfr/react-dsfr/RadioButtons";
 import TdModal from "../Apps/common/Components/Modal/Modal";
 import { envConfig } from "../common/envConfig";
 
@@ -10,20 +11,35 @@ type RecoveryErrorCode =
   | "MISSING_RECOVERY_CODE"
   | "RECOVERY_LOCKOUT";
 
+type RecoveryAction = "RESET" | "TEMPORARY";
+
 type Props = {
   onClose: () => void;
   errorCode?: RecoveryErrorCode | string | null;
   returnTo?: string;
+  attemptsRemaining?: number | string | null;
 };
 
-const title = "Je n'ai pas accès à l'application";
+const title =
+  "Je n'ai pas accès à mon application d'authentification multifactorielle";
+
+function attemptsRemainingLabel(attemptsRemaining: number): string {
+  return attemptsRemaining === 1
+    ? "Il vous reste 1 tentative."
+    : `Il vous reste ${attemptsRemaining} tentatives.`;
+}
 
 export default function RecoveryCodeModal({
   onClose,
   errorCode,
-  returnTo
+  returnTo,
+  attemptsRemaining
 }: Props) {
   const [code, setCode] = useState("");
+  const [recoveryAction, setRecoveryAction] = useState<RecoveryAction | null>(
+    null
+  );
+  const [showSelectionError, setShowSelectionError] = useState(false);
   const formRef = createRef<HTMLFormElement>();
   const { VITE_API_ENDPOINT } = envConfig;
 
@@ -32,15 +48,19 @@ export default function RecoveryCodeModal({
     errorCode === "INVALID_RECOVERY_CODE" ||
     errorCode === "MISSING_RECOVERY_CODE";
 
+  const parsedAttemptsRemaining =
+    attemptsRemaining != null ? Number(attemptsRemaining) : null;
+
   const topAlert = isLockout ? (
     <div className="fr-mb-3w">
       <Alert
-        title="Compte suspendu"
+        title="Fonctionnalité de récupération suspendue"
         description={
           <>
-            Suite aux 3 tentatives successives en erreur. Votre compte est
-            temporairement suspendu, contactez notre support via l'Assistance
-            Trackdéchets.
+            Suite aux 3 tentatives successives en erreur, la fonctionnalité de
+            récupération est temporairement suspendue pendant 1h. Merci de bien
+            vouloir réessayer plus tard ou contacter notre support via
+            l'Assistance Trackdéchets.
             <br />
             <a
               href="https://assistance.trackdechets.beta.gouv.fr/"
@@ -48,7 +68,7 @@ export default function RecoveryCodeModal({
               target="_blank"
               rel="noopener noreferrer"
             >
-              Contacter l’assistance.
+              Contacter l'assistance.
             </a>
           </>
         }
@@ -64,7 +84,11 @@ export default function RecoveryCodeModal({
           <>
             La clé renseignée est incorrecte, merci de bien vouloir vérifier le
             code renseigné ou d'en utiliser un autre. Attention 3 tentatives
-            successives en échec déclenchera une suspension du compte.
+            successives en échec entraînera une suspension pendant 1h de la
+            fonctionnalité de récupération.
+            {parsedAttemptsRemaining != null && (
+              <> {attemptsRemainingLabel(parsedAttemptsRemaining)}</>
+            )}
           </>
         }
         severity="error"
@@ -76,7 +100,7 @@ export default function RecoveryCodeModal({
     <TdModal isOpen onClose={onClose} ariaLabel={title} title={title} size="L">
       {topAlert}
       {invalidCodeAlert}
-      <p className="fr-text--lead fr-mb-3w">
+      <p className="fr-text--lead fr-mb-1w">
         Veuillez renseigner la clé de récupération
       </p>
       <form
@@ -86,10 +110,53 @@ export default function RecoveryCodeModal({
         onSubmit={e => {
           if (isLockout) {
             e.preventDefault();
+            return;
+          }
+          if (!recoveryAction) {
+            e.preventDefault();
+            setShowSelectionError(true);
           }
         }}
       >
         {returnTo && <input type="hidden" name="returnTo" value={returnTo} />}
+        <input
+          type="hidden"
+          name="recoveryAction"
+          value={recoveryAction ?? ""}
+        />
+
+        <p className="fr-mb-2w">
+          A la validation de votre code de récupération vous pourrez :
+        </p>
+
+        <RadioButtons
+          legend=""
+          disabled={isLockout}
+          options={[
+            {
+              label:
+                "Soit réinitialiser votre authentification multifactorielle (ce parcours nécessite votre téléphone pour pouvoir poursuivre)",
+              nativeInputProps: {
+                checked: recoveryAction === "RESET",
+                onChange: () => {
+                  setRecoveryAction("RESET");
+                  setShowSelectionError(false);
+                }
+              }
+            },
+            {
+              label:
+                "Soit utiliser ce code pour vous connecter une fois à la plateforme. Ce code sera consommé et ne pourra plus être utilisé. Après utilisation de votre dernier code cette option ne sera plus disponible et il vous faudra réinitialiser votre authentification multifactorielle",
+              nativeInputProps: {
+                checked: recoveryAction === "TEMPORARY",
+                onChange: () => {
+                  setRecoveryAction("TEMPORARY");
+                  setShowSelectionError(false);
+                }
+              }
+            }
+          ]}
+        />
 
         <Input
           label="Clé de récupération"
@@ -120,6 +187,11 @@ export default function RecoveryCodeModal({
             Se connecter
           </Button>
         </div>
+        {showSelectionError && (
+          <p className="fr-error-text fr-mt-1w fr-mb-0 fr-text--right">
+            Merci de sélectionner une option pour poursuivre.
+          </p>
+        )}
       </form>
     </TdModal>
   );

--- a/front/src/login/RecoveryCodeModal.tsx
+++ b/front/src/login/RecoveryCodeModal.tsx
@@ -99,7 +99,7 @@ export default function RecoveryCodeModal({
             name: "recoveryCode",
             value: code,
             autoComplete: "off",
-            placeholder: "Ex : ABCDE-FGHIJ",
+            placeholder: "Ex : ABCDE-FGHIJ-KLMNO-PQRST",
             onChange: e => setCode(e.target.value),
             disabled: isLockout
           }}

--- a/front/src/login/SecondFactor.tsx
+++ b/front/src/login/SecondFactor.tsx
@@ -51,9 +51,15 @@ const RECOVERY_ERROR_CODES = new Set([
 ]);
 
 function buildQueryRedirectState(queries: queryString.ParsedQuery) {
-  const { errorCode, returnTo, username, lockout = 0 } = queries;
+  const {
+    errorCode,
+    returnTo,
+    username,
+    lockout = 0,
+    attemptsRemaining
+  } = queries;
   return {
-    ...(errorCode ? { errorCode, username, lockout } : {}),
+    ...(errorCode ? { errorCode, username, lockout, attemptsRemaining } : {}),
     ...(returnTo ? { returnTo } : {})
   };
 }
@@ -160,7 +166,7 @@ export default function SecondFactor() {
     );
   }
 
-  const { returnTo, lockout } = stateFromLocation;
+  const { returnTo, lockout, attemptsRemaining } = stateFromLocation;
   const lockoutTimestamp = lockout ? Number(lockout) : undefined;
 
   const isLockout = code === "TOTP_LOCKOUT";
@@ -174,6 +180,7 @@ export default function SecondFactor() {
           onClose={() => setIsRecoveryModalOpen(false)}
           errorCode={isRecoveryError ? code : null}
           returnTo={returnTo}
+          attemptsRemaining={isRecoveryError ? attemptsRemaining : null}
         />
       )}
 

--- a/front/src/login/__tests__/RecoveryCodeModal.test.tsx
+++ b/front/src/login/__tests__/RecoveryCodeModal.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import RecoveryCodeModal from "../RecoveryCodeModal";
+
+function renderModal(
+  props: Partial<React.ComponentProps<typeof RecoveryCodeModal>> = {}
+) {
+  return render(<RecoveryCodeModal onClose={jest.fn()} {...props} />);
+}
+
+describe("<RecoveryCodeModal />", () => {
+  it("displays the two radio options", () => {
+    renderModal();
+
+    expect(
+      screen.getByLabelText(/Soit réinitialiser votre authentification/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Soit utiliser ce code pour vous connecter/)
+    ).toBeInTheDocument();
+  });
+
+  it("blocks submission and shows a message when no option is selected", () => {
+    renderModal();
+
+    const codeInput = screen.getByLabelText("Clé de récupération");
+    fireEvent.change(codeInput, {
+      target: { value: "ABCDE-FGHIJ-KLMNO-PQRST" }
+    });
+
+    fireEvent.click(screen.getByText("Se connecter"));
+
+    expect(
+      screen.getByText("Merci de sélectionner une option pour poursuivre.")
+    ).toBeInTheDocument();
+  });
+
+  it("clears the selection error once an option is picked", () => {
+    renderModal();
+
+    const codeInput = screen.getByLabelText("Clé de récupération");
+    fireEvent.change(codeInput, {
+      target: { value: "ABCDE-FGHIJ-KLMNO-PQRST" }
+    });
+    fireEvent.click(screen.getByText("Se connecter"));
+    expect(
+      screen.getByText("Merci de sélectionner une option pour poursuivre.")
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByLabelText(/Soit réinitialiser votre authentification/)
+    );
+
+    expect(
+      screen.queryByText("Merci de sélectionner une option pour poursuivre.")
+    ).not.toBeInTheDocument();
+  });
+
+  it("reflects the RESET selection in the hidden recoveryAction field", () => {
+    renderModal();
+
+    fireEvent.click(
+      screen.getByLabelText(/Soit réinitialiser votre authentification/)
+    );
+
+    const hiddenInput = document.querySelector(
+      'input[name="recoveryAction"]'
+    ) as HTMLInputElement;
+    expect(hiddenInput.value).toBe("RESET");
+  });
+
+  it("reflects the TEMPORARY selection in the hidden recoveryAction field", () => {
+    renderModal();
+
+    fireEvent.click(
+      screen.getByLabelText(/Soit utiliser ce code pour vous connecter/)
+    );
+
+    const hiddenInput = document.querySelector(
+      'input[name="recoveryAction"]'
+    ) as HTMLInputElement;
+    expect(hiddenInput.value).toBe("TEMPORARY");
+  });
+
+  it("displays the 2 remaining attempts counter", () => {
+    renderModal({ errorCode: "INVALID_RECOVERY_CODE", attemptsRemaining: 2 });
+
+    expect(
+      screen.getByText(/Il vous reste 2 tentatives\./)
+    ).toBeInTheDocument();
+  });
+
+  it("displays the 1 remaining attempt counter with singular wording", () => {
+    renderModal({ errorCode: "INVALID_RECOVERY_CODE", attemptsRemaining: 1 });
+
+    expect(screen.getByText(/Il vous reste 1 tentative\./)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Il vous reste 1 tentatives\./)
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays the 1h suspension message on lockout", () => {
+    renderModal({ errorCode: "RECOVERY_LOCKOUT" });
+
+    expect(
+      screen.getByText(/temporairement suspendue pendant 1h/)
+    ).toBeInTheDocument();
+  });
+
+  it("masks the recovery code field by default", () => {
+    renderModal();
+
+    const codeInput = screen.getByLabelText(
+      "Clé de récupération"
+    ) as HTMLInputElement;
+    expect(codeInput.type).toBe("password");
+  });
+});


### PR DESCRIPTION
# Contexte

Dans le cadre de l’évolution du parcours MFA de Trackdéchets, ce ticket vise à améliorer l’utilisation des codes de récupération lorsqu’un utilisateur n’a plus accès à son application d’authentification.
Il clarifie les choix possibles pour l’utilisateur : réinitialiser sa MFA ou utiliser un code pour une connexion temporaire unique, tout en renforçant le format des codes et la gestion des tentatives invalides.


# Démo

**Cocher 1er choix**

https://github.com/user-attachments/assets/b3bbba33-798e-448b-b51b-9201c265cd0c

**Cas de code erroné**

<img width="999" height="827" alt="image" src="https://github.com/user-attachments/assets/5e6676f6-448b-493d-a7ea-8f35a9b60079" />

**Après trois tentatives**

<img width="841" height="761" alt="image" src="https://github.com/user-attachments/assets/96fc5a8e-fbaf-4829-8bde-67574ad155a0" />


**Cocher 2ème choix**

https://github.com/user-attachments/assets/d097c3e5-5ead-497d-a318-c0047278b2ca



# Ticket Favro

[MFA - Récupérer son compte via un code de récupération - Evolutions](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-18499)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB