### PR TITLE
feat(TRA-18381): Mentions Légales - Politique de confidentialité a intégrer en page WEB et non PDF

### DIFF
--- a/front/src/Apps/common/Components/layout/Footer.tsx
+++ b/front/src/Apps/common/Components/layout/Footer.tsx
@@ -156,9 +156,7 @@ export default function AppFooter() {
               <li className="fr-footer__bottom-item">
                 <a
                   className="fr-footer__bottom-link"
-                  href="/Mentions-legales.pdf"
-                  target="_blank"
-                  rel="noopener"
+                  href="//trackdechets.beta.gouv.fr/mentions-legales/"
                 >
                   Mentions légales
                 </a>
@@ -167,9 +165,7 @@ export default function AppFooter() {
               <li className="fr-footer__bottom-item">
                 <a
                   className="fr-footer__bottom-link"
-                  href="/Politique-de-confidentialite.pdf"
-                  target="_blank"
-                  rel="noopener"
+                  href="//trackdechets.beta.gouv.fr/politiques-confidentialites/"
                 >
                   Politique de confidentialité
                 </a>


### PR DESCRIPTION
# Contexte

Actuellement, les mentions légales et la politique de confidentialité de Trackdéchets sont accessibles depuis le pied de page sous forme de documents PDF. Ce ticket vise à les intégrer directement dans des pages Web, sur le même modèle que les Conditions Générales d’Utilisation, tout en mettant à jour la politique de confidentialité avec les informations relatives aux cookies et au chatbot Crisp.

# Démo
**Page mentions légales:**

https://github.com/user-attachments/assets/c3663500-287d-4b84-8a6b-866e1a0b4852

**Page Politiques de confidentilaités:**

https://github.com/user-attachments/assets/a8e76e79-50b7-4143-b241-8e868b9392e2



# Ticket Favro

[Mentions Légales - Politique de confidentialité a intégrer en page WEB et non PDF](https://favro.com/organization/ab14a4f0460a99a9d64d4945/blank?card=tra-18381)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB