### PR TITLE
tra-18415 : BSVHU & BSFF — Absence d'apparition dans le registre établissement dès la signature producteur

### DIFF
--- a/back/src/bsffs/registryV2.ts
+++ b/back/src/bsffs/registryV2.ts
@@ -1303,6 +1303,7 @@ const minimalBsffForLookupSelect = {
   id: true,
   createdAt: true,
   destinationReceptionSignatureDate: true,
+  emitterEmissionSignatureDate: true,
   destinationReceptionDate: true,
   destinationCompanySiret: true,
   wasteCode: true,
@@ -1345,15 +1346,25 @@ const bsffToLookupCreateInputs = (
       bsffId: bsff.id
     });
   }
-  if (transporter?.transporterTransportSignatureDate) {
+
+  // le registre sortant est alimenté dès la signature émetteur,
+  // la date bascule sur la date d'enlèvement à la signature transporteur
+  const outgoingDate =
+    transporter?.transporterTransportTakenOverAt ??
+    transporter?.transporterTransportSignatureDate ??
+    bsff.emitterEmissionSignatureDate;
+
+  if (outgoingDate) {
     const sirets = new Set([
       bsff.emitterCompanySiret,
       ...bsff.detenteurCompanySirets
     ]);
+
     sirets.forEach(siret => {
       if (!siret) {
         return;
       }
+
       res.push({
         id: bsff.id,
         readableId: bsff.id,
@@ -1362,11 +1373,7 @@ const bsffToLookupCreateInputs = (
         declarationType: RegistryExportDeclarationType.BSD,
         wasteType: RegistryExportWasteType.DD,
         wasteCode: bsff.wasteCode,
-        ...generateDateInfos(
-          transporter.transporterTransportTakenOverAt ??
-            transporter.transporterTransportSignatureDate!,
-          bsff.createdAt
-        ),
+        ...generateDateInfos(outgoingDate, bsff.createdAt),
         bsffId: bsff.id
       });
     });

--- a/back/src/bsvhu/registryV2.ts
+++ b/back/src/bsvhu/registryV2.ts
@@ -1397,6 +1397,7 @@ const minimalBsvhuForLookupSelect = {
   id: true,
   createdAt: true,
   destinationOperationSignatureDate: true,
+  emitterEmissionSignatureDate: true,
   destinationReceptionDate: true,
   destinationCompanySiret: true,
   emitterCompanySiret: true,
@@ -1452,7 +1453,13 @@ const bsvhuToLookupCreateInputs = (
       bsvhuId: bsvhu.id
     });
   }
-  if (transporter?.transporterTransportSignatureDate) {
+  // le registre sortant est alimenté dès la signature émetteur,
+  // la date bascule sur la date d'enlèvement à la signature transporteur
+  const outgoingDate =
+    transporter?.transporterTransportTakenOverAt ??
+    transporter?.transporterTransportSignatureDate ??
+    bsvhu.emitterEmissionSignatureDate;
+  if (outgoingDate) {
     const outgoingSirets = new Set([
       bsvhu.emitterCompanySiret,
       bsvhu.ecoOrganismeSiret
@@ -1469,14 +1476,12 @@ const bsvhuToLookupCreateInputs = (
         declarationType: RegistryExportDeclarationType.BSD,
         wasteType: RegistryExportWasteType.DD,
         wasteCode: bsvhu.wasteCode,
-        ...generateDateInfos(
-          transporter.transporterTransportTakenOverAt ??
-            transporter.transporterTransportSignatureDate!,
-          bsvhu.createdAt
-        ),
+        ...generateDateInfos(outgoingDate, bsvhu.createdAt),
         bsvhuId: bsvhu.id
       });
     });
+  }
+  if (transporter?.transporterTransportSignatureDate) {
     const managedSirets = new Set([
       bsvhu.brokerCompanySiret,
       bsvhu.traderCompanySiret


### PR DESCRIPTION

# Contexte

Les bordereaux BSFF et BSVHU n'apparaissent dans le registre sortant qu'après la signature du transporteur, alors qu'ils devraient être disponibles dès la signature de l'émetteur, comme les BSDD.

Problème
La création du lookup OUTGOING est actuellement conditionnée à la signature du transporteur (transporterTransportSignatureDate), ce qui empêche la génération de l'entrée du registre sortant après la signature de l'émetteur.

Solution
Adapter la génération du lookup OUTGOING pour le créer dès la signature de l'émetteur (emitterEmissionSignatureDate), tout en conservant la mise à jour des informations lors des étapes suivantes du cycle de vie du bordereau.

# Points de vigilance pour les intégrateurs


# Démo

[TD-Registre-20260721-Sortant-00000000000705 (1).csv](https://github.com/user-attachments/files/30222153/TD-Registre-20260721-Sortant-00000000000705.1.csv)


# Ticket Favro

[BSVHU & BSFF — Absence d'apparition dans le registre établissement dès la signature producteur](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18415)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB