### PR TITLE
TRA-18032: Matomo : Identifier les applications concernées par Matomo Beta.Gouv (Trackdechet)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,7 @@ CRISP
 #### :nail_care: Améliorations
 
 - Trackdéchets & Registre exhaustif : Ajouter Conditionnement : (Nombre, Type et Volume) [PR-4825] (https://github.com/MTES-MCT/trackdechets/pull/4825)
+- Matomo : Identifier les applications concernées par Matomo Beta.Gouv [PR-4843] (https://github.com/MTES-MCT/trackdechets/pull/4843)
 
 #### :bug: Corrections de bugs
 

--- a/front/.env.model
+++ b/front/.env.model
@@ -8,9 +8,14 @@ VITE_NOTIFIER_ENDPOINT=http://notifier.trackdechets.local
 VITE_URL_SCHEME=
 VITE_HOSTNAME=
 
-# Matomo tracker id (eg. container_abcd123) and url (without scheme: eg matomo.example.com)
+# Matomo numeric site ID and server URL.
+# Tracking is disabled when one of these variables is not provided.
+# Matomo is configured without cookies.
+#
+# Example:
+# VITE_MATOMO_TRACKER_SITE_ID=111
+# VITE_MATOMO_TRACKER_URL=https://wwwstats.brgm.fr/
 
-# Tracking is disabled when those variables are not provided
 # VITE_MATOMO_TRACKER_SITE_ID=
 # VITE_MATOMO_TRACKER_URL=
 

--- a/front/src/common/tracking/Tracking.tsx
+++ b/front/src/common/tracking/Tracking.tsx
@@ -1,72 +1,113 @@
 import { useEffect } from "react";
-import { useAuth } from "../contexts/AuthContext";
+
 import { envConfig } from "../envConfig";
 
 declare global {
   interface Window {
-    _mtm?: Array<Record<string, any>>;
+    _paq?: Array<unknown[]>;
     _matomoLoaded?: boolean;
-    matomoHeatmapSessionRecordingAsyncInit?: (args: any) => void;
-    Matomo: any;
+    _matomoNavigationTrackingInitialized?: boolean;
   }
 }
 
-window.matomoHeatmapSessionRecordingAsyncInit = function (_: any) {
-  if (window?.Matomo) {
-    window.Matomo.HeatmapSessionRecording.enable();
+function normalizeMatomoUrl(url: string): string {
+  const urlWithScheme =
+    url.startsWith("http://") || url.startsWith("https://")
+      ? url
+      : `https://${url}`;
+
+  return `${urlWithScheme.replace(/\/+$/, "")}/`;
+}
+
+function trackPageView(): void {
+  if (!window._paq) {
+    return;
   }
-};
+
+  window._paq.push(["setCustomUrl", window.location.href]);
+  window._paq.push(["setDocumentTitle", document.title]);
+  window._paq.push(["trackPageView"]);
+}
+
+function initializeNavigationTracking(): void {
+  if (window._matomoNavigationTrackingInitialized) {
+    return;
+  }
+
+  window._matomoNavigationTrackingInitialized = true;
+
+  const originalPushState = window.history.pushState;
+  const originalReplaceState = window.history.replaceState;
+
+  window.history.pushState = function (...args) {
+    originalPushState.apply(this, args);
+
+    window.setTimeout(() => {
+      trackPageView();
+    }, 0);
+  };
+
+  window.history.replaceState = function (...args) {
+    originalReplaceState.apply(this, args);
+
+    window.setTimeout(() => {
+      trackPageView();
+    }, 0);
+  };
+
+  window.addEventListener("popstate", () => {
+    window.setTimeout(() => {
+      trackPageView();
+    }, 0);
+  });
+}
 
 export function MatomoTracker() {
   const { VITE_MATOMO_TRACKER_SITE_ID, VITE_MATOMO_TRACKER_URL } = envConfig;
-  const { user } = useAuth();
-
-  const trackingConsentUntil = user?.trackingConsentUntil;
-  const trackingConsent = user?.trackingConsent;
 
   useEffect(() => {
     if (!VITE_MATOMO_TRACKER_SITE_ID || !VITE_MATOMO_TRACKER_URL) {
       return;
     }
 
-    const hasConsent =
-      trackingConsent &&
-      (trackingConsentUntil
-        ? new Date(trackingConsentUntil) > new Date()
-        : false);
-
-    if (hasConsent) {
-      if (window._matomoLoaded) return;
-
-      const _mtm = (window._mtm = window._mtm || []);
-      _mtm.push({ "mtm.startTime": new Date().getTime(), event: "mtm.Start" });
-
-      const d = document;
-      const g = d.createElement("script");
-      const s = d.getElementsByTagName("script")[0];
-      g.async = true;
-      g.src = `https://${VITE_MATOMO_TRACKER_URL}/js/${VITE_MATOMO_TRACKER_SITE_ID}.js`;
-
-      if (s.parentNode) {
-        s.parentNode.insertBefore(g, s);
-      }
-
-      window._matomoLoaded = true;
+    if (window._matomoLoaded) {
+      return;
     }
 
-    if (!hasConsent) {
-      // Remove Matomo script when consent is withdrawn
-      if (window._matomoLoaded) {
-        // the process of removing in-memory matomo code is a pita, let's just refesh the page
-        window.location.reload();
-      }
-    }
-  }, [
-    trackingConsentUntil,
-    trackingConsent,
-    VITE_MATOMO_TRACKER_SITE_ID,
-    VITE_MATOMO_TRACKER_URL
-  ]);
+    const matomoUrl = normalizeMatomoUrl(VITE_MATOMO_TRACKER_URL);
+    const _paq = (window._paq = window._paq || []);
+
+    /*
+     * Trackdéchets utilise Matomo sans cookies.
+     * Cette commande doit être exécutée avant la première page vue.
+     */
+    _paq.push(["disableCookies"]);
+
+    _paq.push(["setTrackerUrl", `${matomoUrl}matomo.php`]);
+    _paq.push(["setSiteId", VITE_MATOMO_TRACKER_SITE_ID]);
+    _paq.push(["enableLinkTracking"]);
+
+    trackPageView();
+    initializeNavigationTracking();
+
+    const script = document.createElement("script");
+
+    script.async = true;
+    script.src = `${matomoUrl}matomo.js`;
+    script.dataset.matomo = "true";
+
+    script.onerror = () => {
+      window._matomoLoaded = false;
+
+      console.error(
+        `Impossible de charger Matomo depuis ${script.src}. Vérifiez l'URL BRGM et la CSP.`
+      );
+    };
+
+    document.head.appendChild(script);
+
+    window._matomoLoaded = true;
+  }, [VITE_MATOMO_TRACKER_SITE_ID, VITE_MATOMO_TRACKER_URL]);
 
   return null;
 }


### PR DESCRIPTION
# Contexte

L'intégration Matomo existante ne permettait pas de remonter les statistiques malgré la configuration des variables d'environnement (VITE_MATOMO_TRACKER_SITE_ID et VITE_MATOMO_TRACKER_URL).

Le code utilisait une intégration qui n'était plus adaptée au mode de fonctionnement retenu pour la plateforme. Cette PR met à jour l'initialisation de Matomo afin d'utiliser le tracker standard, sans dépendre d'un mécanisme de consentement, et d'assurer le suivi des pages sur les applications React (SPA).

Chaque environnement (production, sandbox, recette, etc.) peut désormais être activé simplement en renseignant son identifiant Matomo et son URL dans les variables Scalingo.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Matomo : Identifier les applications concernées par Matomo Beta.Gouv](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18032)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB