### PR TITLE
correction bug sur pdf type quantité est tjrs reelle meme si la valeur de destination.reception est undefined

### DIFF
--- a/back/src/bsda/pdf/components/BsdaPdf.tsx
+++ b/back/src/bsda/pdf/components/BsdaPdf.tsx
@@ -48,6 +48,8 @@ export function BsdaPdf({
     destinationReceptionWeight: bsda.destination?.reception?.weight
   });
 
+  const weightIsEstimate = bsda?.destination?.reception?.weightIsEstimate;
+
   return (
     <Document title={bsda.id}>
       <div className="Page">
@@ -377,15 +379,13 @@ export function BsdaPdf({
               Type de quantité :{" "}
               <input
                 type="checkbox"
-                checked={!bsda?.destination?.reception?.weightIsEstimate}
+                checked={weightIsEstimate === false}
                 readOnly
               />{" "}
               Réelle{" "}
               <input
                 type="checkbox"
-                checked={Boolean(
-                  bsda?.destination?.reception?.weightIsEstimate
-                )}
+                checked={weightIsEstimate === true}
                 readOnly
               />{" "}
               Estimée


### PR DESCRIPTION
# Contexte

Lors de la génération du PDF BSDA, le type de quantité est déterminé à partir de destination.reception.weightIsEstimate.
Lorsque destination.reception est null (aucune réception renseignée), le code utilisait :

checked={!bsda?.destination?.reception?.weightIsEstimate}

En JavaScript, !undefined vaut true, ce qui cochait par défaut "Réelle" alors qu'aucune valeur n'était renseignée.

Cette PR remplace cette logique par des comparaisons strictes (=== true / === false) afin de distinguer explicitement les trois cas :

true → Estimée cochée ;
false → Réelle cochée ;
null / undefined → aucune case cochée.

Cela évite d'interpréter l'absence de valeur comme une quantité réelle et garantit un rendu fidèle aux données du bordereau.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB