### PR TITLE
feat(TRA-18542): Retirer la limite des 18 mois pour permettre à certains SIRET de déclarer à +18 mois

### DIFF
--- a/front/src/form/registry/builder/FormTab.tsx
+++ b/front/src/form/registry/builder/FormTab.tsx
@@ -11,7 +11,10 @@ import { envConfig } from "../../../common/envConfig";
 import type { FormShapeFieldWithState } from "./types";
 import { formatError } from "./error";
 import "./FormTab.scss";
-import { MIN_DATE_FOR_REGISTRY } from "@td/constants";
+import {
+  MIN_DATE_FOR_REGISTRY,
+  isSiretExemptFromRegistryDateLimit
+} from "@td/constants";
 
 type Props = { fields: FormShapeFieldWithState[]; methods: UseFormReturn<any> };
 
@@ -19,7 +22,9 @@ export function FormTab({ fields, methods }: Props) {
   const { errors } = methods.formState;
   const reportForCompanySiret = methods.watch("reportForCompanySiret");
   const noDateLimit = useMemo(
-    () => envConfig.VITE_NO_DATE_LIMIT_SIRETS.includes(reportForCompanySiret),
+    () =>
+      envConfig.VITE_NO_DATE_LIMIT_SIRETS.includes(reportForCompanySiret) ||
+      isSiretExemptFromRegistryDateLimit(reportForCompanySiret),
     [reportForCompanySiret]
   );
 

--- a/libs/back/registry/src/shared/refinement.ts
+++ b/libs/back/registry/src/shared/refinement.ts
@@ -3,7 +3,8 @@ import {
   FINAL_OPERATION_CODES,
   MIN_DATE_FOR_REGISTRY,
   TdOperationCode,
-  isSiret
+  isSiret,
+  isSiretExemptFromRegistryDateLimit
 } from "@td/constants";
 import { envConfig } from "../config";
 import { checkVAT, countries } from "jsvat";
@@ -706,7 +707,10 @@ export const refineDateLimits =
   ): Refinement<T> =>
   (item, { addIssue }) => {
     const reportForSiret = item.reportForCompanySiret;
-    if (envConfig.NO_DATE_LIMIT_SIRETS.includes(reportForSiret)) {
+    if (
+      envConfig.NO_DATE_LIMIT_SIRETS.includes(reportForSiret) ||
+      isSiretExemptFromRegistryDateLimit(reportForSiret)
+    ) {
       return;
     }
     for (const dateField of dateFields) {

--- a/libs/shared/constants/src/VALIDATION.ts
+++ b/libs/shared/constants/src/VALIDATION.ts
@@ -16,3 +16,27 @@ export const MIN_DATE_FOR_REGISTRY = {
   years: 1,
   months: 6
 };
+
+// Dérogation temporaire à la limite de 18 mois pour la saisie/modification
+// dans les registres, accordée à certains SIRET le temps qu'ils se mettent
+// en conformité sur demande de leur DREAL (validation DGPR).
+// Reprend le mécanisme de liste de SIRET exemptés mis en place pour
+// permettre la saisie à plus de 18 mois, borné dans le temps.
+export const TEMPORARY_REGISTRY_DATE_LIMIT_EXEMPTION_SIRETS = [
+  "25270386300024", // PRECOVAL - Malleville-sur-le-Bec (27)
+  "48118481000010" // Les Champs Jouault - Cuves (50)
+];
+
+export const TEMPORARY_REGISTRY_DATE_LIMIT_EXEMPTION_END_DATE = new Date(
+  "2026-12-31T23:59:59.999+01:00"
+);
+
+export function isSiretExemptFromRegistryDateLimit(
+  siret: string,
+  now: Date = new Date()
+): boolean {
+  return (
+    TEMPORARY_REGISTRY_DATE_LIMIT_EXEMPTION_SIRETS.includes(siret) &&
+    now <= TEMPORARY_REGISTRY_DATE_LIMIT_EXEMPTION_END_DATE
+  );
+}

--- a/libs/shared/constants/src/__tests__/VALIDATION.test.ts
+++ b/libs/shared/constants/src/__tests__/VALIDATION.test.ts
@@ -1,0 +1,33 @@
+import {
+  isSiretExemptFromRegistryDateLimit,
+  TEMPORARY_REGISTRY_DATE_LIMIT_EXEMPTION_SIRETS,
+  TEMPORARY_REGISTRY_DATE_LIMIT_EXEMPTION_END_DATE
+} from "../VALIDATION";
+
+describe("isSiretExemptFromRegistryDateLimit", () => {
+  const exemptSiret = TEMPORARY_REGISTRY_DATE_LIMIT_EXEMPTION_SIRETS[0];
+  const beforeEnd = new Date(
+    TEMPORARY_REGISTRY_DATE_LIMIT_EXEMPTION_END_DATE.getTime() - 1000
+  );
+  const afterEnd = new Date(
+    TEMPORARY_REGISTRY_DATE_LIMIT_EXEMPTION_END_DATE.getTime() + 1000
+  );
+
+  test("returns true for an exempted siret before the end date", () => {
+    expect(isSiretExemptFromRegistryDateLimit(exemptSiret, beforeEnd)).toBe(
+      true
+    );
+  });
+
+  test("returns false for an exempted siret after the end date", () => {
+    expect(isSiretExemptFromRegistryDateLimit(exemptSiret, afterEnd)).toBe(
+      false
+    );
+  });
+
+  test("returns false for a siret that is not in the exemption list", () => {
+    expect(
+      isSiretExemptFromRegistryDateLimit("11111111100011", beforeEnd)
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
# Contexte

Le ticket concerne la levée temporaire de la restriction des 18 mois sur la saisie et la modification dans les registres. L’objectif est de permettre uniquement à certains SIRET autorisés de saisir ou modifier des données à des dates beaucoup plus anciennes, afin de répondre aux demandes de mise en conformité des DREAL. Cette exception est valable temporairement jusqu’au 31/12/2026.

# Démo

https://github.com/user-attachments/assets/0bdcf573-f1e7-4623-a476-dbbe04e39f89



# Ticket Favro

[Retirer la limite des 18 mois pour permettre à certains SIRET de déclarer à +18 mois](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18542)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB