### PR TITLE
fix/TRA-18649: BSFF - Aperçu - Absence de l'onglet transporteur

### DIFF
--- a/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewContent.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewContent.tsx
@@ -77,15 +77,11 @@ const BSFFPreviewContent = ({ bsdId }: BSFFPreviewContentProps) => {
           }
         ]
       : []),
-    ...(!(bsd?.type === BsffType.TracerFluide)
-      ? [
-          {
-            tabId: "transport",
-            label: "Transporteur" + (isMultiModal ? "s" : ""),
-            iconId: "ri-truck-fill" as RiIconClassName
-          }
-        ]
-      : []),
+    {
+      tabId: "transport",
+      label: "Transporteur" + (isMultiModal ? "s" : ""),
+      iconId: "ri-truck-fill" as RiIconClassName
+    },
     {
       tabId: "destination",
       label: "Destinataire",


### PR DESCRIPTION
# Contexte

Afficher l'onglet Transporteur/s Bsff - APERCU

# Points de vigilance pour les intégrateurs


# Démo


https://github.com/user-attachments/assets/5bd8c591-392f-4612-ba4a-7673484ea3d5



# Ticket Favro

[BSFF - Aperçu - Absence de l'onglet transporteur](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18649)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB