### PR TITLE
BSFF - Aperçu - Opération réalisée et Date de traitement  renseignées dès la réception du bordereau

### DIFF
--- a/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewWaste.tsx
+++ b/front/src/Apps/Dashboard/Preview/BSFF/BSFFPreviewWaste.tsx
@@ -50,14 +50,24 @@ const BSFFPreviewWaste = ({ bsd }: BSFFPreviewWasteProps) => {
         <PreviewContainerCol gridWidth={4}>
           <PreviewTextRow
             label="Opération réalisée"
-            value={bsd.destination?.plannedOperationCode}
+            value={
+              bsd.packagings?.length === 1 &&
+              bsd.packagings[0].operation?.signature?.date
+                ? bsd.packagings[0].operation?.code
+                : "-"
+            }
           />
         </PreviewContainerCol>
 
         <PreviewContainerCol gridWidth={4}>
           <PreviewDateRow
             label="Date de traitement"
-            value={bsd.destination?.reception?.date}
+            value={
+              bsd.packagings?.length === 1 &&
+              bsd.packagings[0].operation?.signature?.date
+                ? bsd.packagings[0].operation?.date
+                : undefined
+            }
           />
         </PreviewContainerCol>
       </PreviewContainerRow>


### PR DESCRIPTION

# Contexte

Les champs opération réalisée et date de traitement sont renseignés (sans date de traitement) dès la publication d'un bordereau alors que ce ne devrait être le cas qu'après traitement des contenants. (tous parcours)

# Points de vigilance pour les intégrateurs


# Démo

https://github.com/user-attachments/assets/78d02cd1-7006-4e7f-94aa-b503417b00e1



# Ticket Favro

[BSFF - Aperçu - Opération réalisée renseignée dès la publication](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18650)
[BSFF - Aperçu - Date de traitement renseignée dès la réception du bordereau](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-18656)
# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB